### PR TITLE
CSB-378 Changes to productization list to match camel

### DIFF
--- a/.mvn/excludes.txt
+++ b/.mvn/excludes.txt
@@ -34,7 +34,6 @@
 :camel-azure-storage-datalake-starter
 :camel-barcode-starter
 :camel-base64-starter
-:camel-bean-validator-starter
 :camel-beanio-starter
 :camel-beanstalk-starter
 :camel-bonita-starter
@@ -73,13 +72,13 @@
 :camel-drill-starter
 :camel-dropbox-starter
 :camel-ehcache-starter
+:camel-elasticsearch-rest-starter
 :camel-elsql-starter
 :camel-etcd-starter
 :camel-etcd3-starter
 :camel-exec-starter
 :camel-facebook-starter
 :camel-fastjson-starter
-:camel-fhir-starter
 :camel-file-watch-starter
 :camel-flatpack-starter
 :camel-flink-starter
@@ -118,7 +117,6 @@
 :camel-iec60870-starter
 :camel-ignite-starter
 :camel-infinispan-embedded-starter
-:camel-infinispan-starter
 :camel-influxdb-starter
 :camel-iota-starter
 :camel-ipfs-starter
@@ -160,7 +158,6 @@
 :camel-lucene-starter
 :camel-lumberjack-starter
 :camel-lzf-starter
-:camel-mail-starter
 :camel-metrics-starter
 :camel-micrometer-starter
 :camel-milo-starter
@@ -185,7 +182,6 @@
 :camel-opentracing-starter
 :camel-optaplanner-starter
 :camel-paho-mqtt5-starter
-:camel-paho-starter
 :camel-pdf-starter
 :camel-pg-replication-slot-starter
 :camel-pgevent-starter
@@ -194,7 +190,6 @@
 :camel-protobuf-starter
 :camel-pubnub-starter
 :camel-pulsar-starter
-:camel-quartz-starter
 :camel-quickfix-starter
 :camel-rabbitmq-starter
 :camel-reactive-streams-starter
@@ -273,7 +268,6 @@
 :camel-yammer-starter
 :camel-zendesk-starter
 :camel-zip-deflater-starter
-:camel-zipfile-starter
 :camel-zipkin-starter
 :camel-zookeeper-master-starter
 :camel-zookeeper-starter

--- a/components-starter/pom.xml
+++ b/components-starter/pom.xml
@@ -155,7 +155,7 @@
     <!-- <module>camel-barcode-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-base64-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <module>camel-bean-starter</module>
-    <!-- <module>camel-bean-validator-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
+    <module>camel-bean-validator-starter</module>
     <!-- <module>camel-beanio-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-beanstalk-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <module>camel-bindy-starter</module>
@@ -203,14 +203,14 @@
     <!-- <module>camel-drill-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-dropbox-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-ehcache-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
-    <module>camel-elasticsearch-rest-starter</module>
+    <!-- <module>camel-elasticsearch-rest-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-elsql-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-etcd-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-etcd3-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-exec-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-facebook-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-fastjson-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
-    <!-- <module>camel-fhir-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
+    <module>camel-fhir-starter</module>
     <module>camel-file-starter</module>
     <!-- <module>camel-file-watch-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-flatpack-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
@@ -254,7 +254,7 @@
     <!-- <module>camel-iec60870-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-ignite-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-infinispan-embedded-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
-    <!-- <module>camel-infinispan-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
+    <module>camel-infinispan-starter</module>
     <!-- <module>camel-influxdb-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-iota-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-ipfs-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
@@ -308,7 +308,7 @@
     <!-- <module>camel-lucene-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-lumberjack-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-lzf-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
-    <!-- <module>camel-mail-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
+    <module>camel-mail-starter</module>
     <module>camel-master-starter</module>
     <!-- <module>camel-metrics-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-micrometer-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
@@ -339,7 +339,7 @@
     <!-- <module>camel-opentracing-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-optaplanner-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-paho-mqtt5-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
-    <!-- <module>camel-paho-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
+    <module>camel-paho-starter</module>
     <!-- <module>camel-pdf-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-pg-replication-slot-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-pgevent-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
@@ -348,7 +348,7 @@
     <!-- <module>camel-protobuf-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-pubnub-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-pulsar-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
-    <!-- <module>camel-quartz-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
+    <module>camel-quartz-starter</module>
     <!-- <module>camel-quickfix-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-rabbitmq-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-reactive-streams-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
@@ -445,7 +445,7 @@
     <!-- <module>camel-yammer-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-zendesk-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-zip-deflater-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
-    <!-- <module>camel-zipfile-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
+    <module>camel-zipfile-starter</module>
     <!-- <module>camel-zipkin-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-zookeeper-master-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-zookeeper-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <spring-boot-version>2.6.4</spring-boot-version>
 
         <!-- Camel target version -->
-        <camel-version>3.14.2.redhat-00001</camel-version>
+        <camel-version>3.14.2.redhat-00005</camel-version>
 
         <!-- cq plugin version -->
         <cq-plugin.version>2.21.0</cq-plugin.version>

--- a/product/src/main/resources/required-productized-camel-artifacts.txt
+++ b/product/src/main/resources/required-productized-camel-artifacts.txt
@@ -14,6 +14,7 @@ camel-azure-storage-blob-starter
 camel-azure-storage-queue-starter
 camel-base-starter
 camel-bean-starter
+camel-bean-validator-starter
 camel-bindy-starter
 camel-cassandraql-starter
 camel-catalog-starter
@@ -27,14 +28,15 @@ camel-cron-starter
 camel-dependencies-starter
 camel-dependencies-generator-starter
 camel-direct-starter
-camel-elasticsearch-rest-starter
 camel-endpointdsl-starter
+camel-fhir-starter
 camel-file-starter
 camel-ftp-starter
 camel-gson-starter
 camel-hl7-starter
 camel-http-starter
 camel-http-common-starter
+camel-infinispan-starter
 camel-jackson-starter
 camel-jackson-avro-starter
 camel-jackson-protobuf-starter
@@ -49,6 +51,7 @@ camel-kafka-starter
 camel-kamelet-starter
 camel-kubernetes-starter
 camel-log-starter
+camel-mail-starter
 camel-main-starter
 camel-master-starter
 camel-microprofile-config-starter
@@ -59,7 +62,9 @@ camel-mock-starter
 camel-mongodb-starter
 camel-netty-starter
 camel-openapi-java-starter
+camel-paho-starter
 camel-platform-http-vertx-starter
+camel-quartz-starter
 camel-rest-starter
 camel-salesforce-starter
 camel-saxon-starter
@@ -76,3 +81,4 @@ camel-xml-io-starter
 camel-xml-io-dsl-starter
 camel-xpath-starter
 camel-yaml-dsl-starter
+camel-zipfile-starter

--- a/tooling/camel-spring-boot-bom/pom.xml
+++ b/tooling/camel-spring-boot-bom/pom.xml
@@ -266,7 +266,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-bean-validator-starter</artifactId>
-        <version>3.14.2</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -506,7 +506,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-elasticsearch-rest-starter</artifactId>
-        <version>${project.version}</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -541,7 +541,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-fhir-starter</artifactId>
-        <version>3.14.2</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -761,7 +761,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-infinispan-starter</artifactId>
-        <version>3.14.2</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -1036,7 +1036,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-mail-starter</artifactId>
-        <version>3.14.2</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -1191,7 +1191,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-paho-starter</artifactId>
-        <version>3.14.2</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -1236,7 +1236,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-quartz-starter</artifactId>
-        <version>3.14.2</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -1751,7 +1751,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-zipfile-starter</artifactId>
-        <version>3.14.2</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -129,7 +129,7 @@
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
-        <version>1.4.19</version>
+        <version>1.4.19.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>
@@ -455,7 +455,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-bean-validator-starter</artifactId>
-        <version>3.14.2</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -695,7 +695,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-elasticsearch-rest-starter</artifactId>
-        <version>${project.version}</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -730,7 +730,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-fhir-starter</artifactId>
-        <version>3.14.2</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -950,7 +950,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-infinispan-starter</artifactId>
-        <version>3.14.2</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -1225,7 +1225,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-mail-starter</artifactId>
-        <version>3.14.2</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -1380,7 +1380,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-paho-starter</artifactId>
-        <version>3.14.2</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -1425,7 +1425,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-quartz-starter</artifactId>
-        <version>3.14.2</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -1945,7 +1945,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-zipfile-starter</artifactId>
-        <version>3.14.2</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -1965,7 +1965,7 @@
       <dependency>
         <groupId>org.apache.camel.tests</groupId>
         <artifactId>org.apache.camel.tests.mock-javamail_1.7</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -1985,7 +1985,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-allcomponents</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
         <type>pom</type>
       </dependency>
       <dependency>
@@ -2001,7 +2001,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-api</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2061,12 +2061,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-attachments</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-avro</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2076,7 +2076,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-avro-rpc-component</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2096,12 +2096,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-avro-spi</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-parent</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2121,12 +2121,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-cw</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ddb</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2156,7 +2156,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-kinesis</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2166,7 +2166,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-lambda</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2181,7 +2181,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-s3</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2191,12 +2191,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sns</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sqs</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2221,7 +2221,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-parent</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2231,7 +2231,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-blob</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2241,7 +2241,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-queue</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2251,12 +2251,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base-engine</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2266,12 +2266,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean-validator</artifactId>
-        <version>3.14.2</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2286,7 +2286,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bindy</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2316,7 +2316,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-browse</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2331,12 +2331,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cassandraql</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2371,12 +2371,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloud</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cluster</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2401,7 +2401,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-componentdsl</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2411,7 +2411,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-controlbus</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2421,37 +2421,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-catalog</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-engine</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-languages</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-model</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-processor</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-reifier</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2471,7 +2471,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cron</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2501,12 +2501,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataformat</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataset</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2526,7 +2526,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debezium-maven-plugin</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2561,12 +2561,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-direct</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-directvm</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2606,7 +2606,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-support</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2616,7 +2616,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch-rest</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2631,7 +2631,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2661,22 +2661,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir</artifactId>
-        <version>3.14.2</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir-api</artifactId>
-        <version>3.14.2</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir-parent</artifactId>
-        <version>3.14.2</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-file</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2706,7 +2706,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ftp</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2816,7 +2816,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-gson</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2846,27 +2846,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-health</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hl7</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-base</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-common</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2931,12 +2931,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan</artifactId>
-        <version>3.14.2</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-common</artifactId>
-        <version>3.14.2</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2946,7 +2946,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-parent</artifactId>
-        <version>3.14.2</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2976,22 +2976,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-avro</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-protobuf</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jacksonxml</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3001,12 +3001,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-java-joor-dsl</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jaxb</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3066,12 +3066,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jira</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jms</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3146,7 +3146,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonpath</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3156,17 +3156,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jta</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kafka</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3186,7 +3186,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kubernetes</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3196,7 +3196,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-language</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3221,7 +3221,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-log</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3246,12 +3246,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail</artifactId>
-        <version>3.14.2</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-main</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3261,12 +3261,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management-api</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-master</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3281,27 +3281,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-config</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-fault-tolerance</artifactId>
-        <version>3.14.2</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-health</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-metrics</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-parent</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3321,17 +3321,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mllp</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mock</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mongodb</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3371,7 +3371,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3431,7 +3431,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-java</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3456,7 +3456,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho</artifactId>
-        <version>3.14.2</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3481,12 +3481,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-vertx</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3511,7 +3511,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-quartz</artifactId>
-        <version>3.14.2</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3546,7 +3546,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ref</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3561,7 +3561,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3606,22 +3606,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saga</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-salesforce</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-salesforce-maven-plugin</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-salesforce-parent</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3631,12 +3631,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saxon</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-scheduler</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3646,7 +3646,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-seda</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3661,7 +3661,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-servicenow-maven-plugin</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3696,7 +3696,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-slack</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3716,7 +3716,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-soap</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3806,7 +3806,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sql</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3841,12 +3841,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stub</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-support</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3871,7 +3871,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-telegram</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3886,12 +3886,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-junit5</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-parent</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3901,7 +3901,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-spring-junit5</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3941,17 +3941,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-timer</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-model</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-util</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3986,17 +3986,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util-json</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-validator</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4011,7 +4011,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-common</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4026,7 +4026,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-parent</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4036,7 +4036,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vm</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4051,7 +4051,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-webhook</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4091,22 +4091,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-dsl</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-util</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxb</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4116,7 +4116,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4131,12 +4131,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xpath</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4151,17 +4151,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-common</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-deserializers</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4181,7 +4181,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zipfile</artifactId>
-        <version>3.14.2</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4201,7 +4201,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>spi-annotations</artifactId>
-        <version>3.14.2.redhat-00001</version>
+        <version>3.14.2.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.cassandra</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/CSB-378

Additions : 

camel-bean-validator, camel-fhir, camel-infinispan, camel-mail, camel-paho, camel-quartz, camel-zipfile

Removals : camel-elasticsearch-rest

I could not find a starter for camel-microprofile-fault-tolerance - I'm not sure one exists in 3.14.2.   I think we may be safe not adding this to the list.