### PR TITLE
Productize camel-jpa-starter

### DIFF
--- a/.mvn/excludes.txt
+++ b/.mvn/excludes.txt
@@ -139,7 +139,6 @@
 :camel-jolt-starter
 :camel-jooq-starter
 :camel-joor-starter
-:camel-jpa-starter
 :camel-jq-starter
 :camel-js-dsl-starter
 :camel-jsch-starter

--- a/components-starter/pom.xml
+++ b/components-starter/pom.xml
@@ -283,7 +283,7 @@
     <!-- <module>camel-jolt-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-jooq-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-joor-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
-    <!-- <module>camel-jpa-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
+    <module>camel-jpa-starter</module>
     <!-- <module>camel-jq-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-jsch-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-jslt-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->

--- a/product/src/main/resources/required-productized-camel-artifacts.txt
+++ b/product/src/main/resources/required-productized-camel-artifacts.txt
@@ -51,6 +51,7 @@ camel-java-joor-dsl-starter
 camel-jaxb-starter
 camel-jira-starter
 camel-jms-starter
+camel-jpa-starter
 camel-jsonpath-starter
 camel-jta-starter
 camel-kafka-starter

--- a/tooling/camel-spring-boot-bom/pom.xml
+++ b/tooling/camel-spring-boot-bom/pom.xml
@@ -961,7 +961,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-jpa-starter</artifactId>
-        <version>3.18.3</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -1159,7 +1159,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-jpa-starter</artifactId>
-        <version>3.18.3</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/CSB-479

camel-jpa is already productized in camel, but we need to add the camel-jpa-starter for CSB-479.