### PR TITLE
CSB-810 Filter out camel-debezium db2/oracle starters and remove deprecated camel-testcontainers-spring artifacts

### DIFF
--- a/tooling/camel-spring-boot-bom/pom.xml
+++ b/tooling/camel-spring-boot-bom/pom.xml
@@ -455,22 +455,12 @@
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>camel-debezium-db2-starter</artifactId>
-        <version>3.18.3</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-debezium-mongodb-starter</artifactId>
         <version>3.18.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-debezium-mysql-starter</artifactId>
-        <version>3.18.3</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>camel-debezium-oracle-starter</artifactId>
         <version>3.18.3</version>
       </dependency>
       <dependency>
@@ -1816,16 +1806,6 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-spring-junit5</artifactId>
-        <version>3.18.3</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel</groupId>
-        <artifactId>camel-testcontainers-spring</artifactId>
-        <version>3.18.3</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel</groupId>
-        <artifactId>camel-testcontainers-spring-junit5</artifactId>
         <version>3.18.3</version>
       </dependency>
     </dependencies>

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -653,22 +653,12 @@
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>camel-debezium-db2-starter</artifactId>
-        <version>3.18.3</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-debezium-mongodb-starter</artifactId>
         <version>3.18.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-debezium-mysql-starter</artifactId>
-        <version>3.18.3</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>camel-debezium-oracle-starter</artifactId>
         <version>3.18.3</version>
       </dependency>
       <dependency>

--- a/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomDependenciesGeneratorMojo.java
+++ b/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomDependenciesGeneratorMojo.java
@@ -218,6 +218,12 @@ public class BomDependenciesGeneratorMojo extends AbstractMojo {
                     File pom = new File(d.toFile(), "pom.xml");
                     return pom.isFile() && pom.exists();
                 })
+                // for 3.18.3, filter out debezium-db2 / debezium-oracle because they were not released
+                // upstream (CAMEL-18746)
+                .filter(d-> {
+                    return (!((d.getFileName().toString().equals("camel-debezium-db2-starter")) ||
+                            (d.getFileName().toString().equals("camel-debezium-oracle-starter"))));
+                })
                 .map(dir -> {
                     Dependency dep = new Dependency();
                     dep.setGroupId("org.apache.camel.springboot");

--- a/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomGeneratorMojo.java
+++ b/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomGeneratorMojo.java
@@ -123,6 +123,12 @@ public class BomGeneratorMojo extends AbstractMojo {
                     File pom = new File(d.toFile(), "pom.xml");
                     return pom.isFile() && pom.exists();
                 })
+                // for 3.18.3, filter out debezium-db2 / debezium-oracle because they were not released
+                // upstream (CAMEL-18746)
+                .filter(d-> {
+                    return (!((d.getFileName().toString().equals("camel-debezium-db2-starter")) ||
+                            (d.getFileName().toString().equals("camel-debezium-oracle-starter"))));
+                })
                 .map(dir -> {
                     Dependency dep = new Dependency();
                     dep.setGroupId("org.apache.camel.springboot");
@@ -245,16 +251,6 @@ public class BomGeneratorMojo extends AbstractMojo {
         dep = new Dependency();
         dep.setGroupId("org.apache.camel");
         dep.setArtifactId("camel-test-spring-junit5");
-        dep.setVersion(camelCommunityVersion);
-        outDependencies.add(dep);
-        dep = new Dependency();
-        dep.setGroupId("org.apache.camel");
-        dep.setArtifactId("camel-testcontainers-spring");
-        dep.setVersion(camelCommunityVersion);
-        outDependencies.add(dep);
-        dep = new Dependency();
-        dep.setGroupId("org.apache.camel");
-        dep.setArtifactId("camel-testcontainers-spring-junit5");
         dep.setVersion(camelCommunityVersion);
         outDependencies.add(dep);
 


### PR DESCRIPTION
https://issues.redhat.com/browse/CSB-810

camel-debezium-db2-starter and camel-debezium-oracle-starter do not exist upstream in camel-spring-boot 3.18.3 - filter them out from the bom and camel-spring-boot-dependencies.    Remove deprecated camel-testcontainers-spring artifacts which do not exist in camel 3.18.3