### PR TITLE
Add a Red Hat camel-spring-boot bom which includes the camel spring-boot bom, spring-boot-dependencies and allows overrides of third party dependencies.

### DIFF
--- a/archetypes/camel-archetype-spring-boot/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/camel-archetype-spring-boot/src/main/resources-filtered/META-INF/maven/archetype-metadata.xml
@@ -24,6 +24,9 @@
     <requiredProperty key="camel-version">
       <defaultValue>${project.version}</defaultValue>
     </requiredProperty>
+    <requiredProperty key="camel-spring-boot-version">
+      <defaultValue>${project.version}</defaultValue>
+    </requiredProperty>
     <requiredProperty key="spring-boot-version">
       <defaultValue>${spring-boot-version}</defaultValue>
     </requiredProperty>

--- a/archetypes/camel-archetype-spring-boot/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/camel-archetype-spring-boot/src/main/resources/archetype-resources/pom.xml
@@ -37,7 +37,7 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.jboss.redhat-fuse</groupId>
+        <groupId>com.redhat.camel.springboot.platform</groupId>
         <artifactId>camel-springboot-bom</artifactId>
         <version>${camel-spring-boot-version}</version>
         <type>pom</type>

--- a/archetypes/camel-archetype-spring-boot/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/camel-archetype-spring-boot/src/main/resources/archetype-resources/pom.xml
@@ -36,19 +36,10 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Spring Boot BOM -->
       <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring.boot-version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <!-- Camel BOM -->
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>camel-spring-boot-bom</artifactId>
-        <version>${camel-version}</version>
+        <groupId>org.jboss.redhat-fuse</groupId>
+        <artifactId>camel-springboot-bom</artifactId>
+        <version>${camel-spring-boot-version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/archetypes/camel-archetype-spring-boot/src/test/resources/projects/build-it/archetype.properties
+++ b/archetypes/camel-archetype-spring-boot/src/test/resources/projects/build-it/archetype.properties
@@ -21,6 +21,7 @@ package=org.apache.camel.archetypes.archetypeIT
 
 # TODO: Remove these, after https://issues.apache.org/jira/browse/ARCHETYPE-574 fixed
 camel-version=${project.version}
+camel-spring-boot-version=${project.version}
 logback-version=${logback-version}
 maven-compiler-plugin-version=${maven-compiler-plugin-version}
 maven-resources-plugin-version=${maven-resources-plugin-version}

--- a/archetypes/camel-archetype-spring-boot/src/test/resources/projects/run-it/archetype.properties
+++ b/archetypes/camel-archetype-spring-boot/src/test/resources/projects/run-it/archetype.properties
@@ -21,6 +21,7 @@ package=org.apache.camel.archetypes.archetypeIT
 
 # TODO: Remove these, after https://issues.apache.org/jira/browse/ARCHETYPE-574 fixed
 camel-version=${project.version}
+camel-spring-boot-version=${project.version}
 logback-version=${logback-version}
 maven-compiler-plugin-version=${maven-compiler-plugin-version}
 maven-resources-plugin-version=${maven-resources-plugin-version}

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2005-2022 Red Hat, Inc.
+
+     Red Hat licenses this file to you under the Apache License, version
+     2.0 (the "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+     implied.  See the License for the specific language governing
+     permissions and limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.redhat-fuse</groupId>
+    <artifactId>camel-springboot-bom</artifactId>
+    <version>3.14.5-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>Red Hat Application Foundations :: ${project.artifactId}</name>
+    <description>Red Hat Application Foundations provides organizations with a comprehensive set of components to develop and modernize their software</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+	<!-- Camel / SpringBoot dependency versions -->
+        <version.camel>3.14.5.redhat-00010</version.camel>
+        <version.camel-spring-boot>3.14.5-SNAPSHOT</version.camel-spring-boot>
+        <version.spring-boot>2.7.4</version.spring-boot>
+
+        <!-- Third party dependency versions -->
+        <version.snakeyaml>1.33</version.snakeyaml>
+
+    </properties>
+
+    <url>https://developers.redhat.com/products/fuse/overview</url>
+
+    <scm>
+        <connection>scm:git:git@github.com:jboss-fuse/redhat-fuse.git</connection>
+        <developerConnection>scm:git:git@github.com:jboss-fuse/redhat-fuse.git</developerConnection>
+        <tag>master</tag>
+    </scm>
+
+    <organization>
+        <name>Red Hat</name>
+        <url>http://redhat.com</url>
+    </organization>
+
+    <developers>
+        <developer>
+            <id>fuseteam</id>
+            <name>Red Hat Development Team</name>
+            <organization>Red Hat</organization>
+            <organizationUrl>http://www.redhat.com/</organizationUrl>
+        </developer>
+    </developers>
+
+    <inceptionYear>2022</inceptionYear>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <!-- These are place holder dependency management entries -->
+    <dependencyManagement>
+        <dependencies>	
+            <!-- Insert third party overrides here -->
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${version.snakeyaml}</version>
+            </dependency>
+            <!-- Spring Boot Dependencies -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${version.spring-boot}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Camel Spring Boot BOM -->
+            <dependency>
+                <groupId>org.apache.camel.springboot</groupId>
+                <artifactId>camel-spring-boot-bom</artifactId>
+                <version>${version.camel-spring-boot}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -20,7 +20,7 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.jboss.redhat-fuse</groupId>
+    <groupId>com.redhat.camel.springboot.platform</groupId>
     <artifactId>camel-springboot-bom</artifactId>
     <version>3.14.5-SNAPSHOT</version>
     <packaging>pom</packaging>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -33,8 +33,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 	<!-- Camel / SpringBoot dependency versions -->
-        <version.camel>3.14.5.redhat-00010</version.camel>
-        <version.camel-spring-boot>3.14.5-SNAPSHOT</version.camel-spring-boot>
+        <version.camel>3.14.5.redhat-00011</version.camel>
+        <version.camel-spring-boot>3.14.5.redhat-00014</version.camel-spring-boot>
         <version.spring-boot>2.7.4</version.spring-boot>
 
         <!-- Third party dependency versions -->


### PR DESCRIPTION
Federico suggested that we add a Red Hat camel-spring-boot bom which includes the camel spring-boot bom, spring-boot-dependencies and allows overrides of third party dependencies.      I'd like to add this to 3.14.5 before we ship the update there so that we check a bunch of CVEs off the list.

Thing I could use help on : 

- **suggestions for the groupId** : currently org.jboss.redhat-fuse - stealing this from the redhat-fuse BOM, can anyone think of a better groupId?     Freeman suggested org.redhat.af, which matches Application Foundations - does anyone know what other newly created RH projects are using?