### PR TITLE
Use elasticsearch-java-client-sniffer-version

### DIFF
--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -83,12 +83,12 @@
             <dependency>
                 <groupId>org.elasticsearch.client</groupId>
                 <artifactId>elasticsearch-rest-client</artifactId>
-                <version>${elasticsearch-java-client-version}</version>
+                <version>${elasticsearch-java-client-sniffer-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.elasticsearch.client</groupId>
                 <artifactId>elasticsearch-rest-client-sniffer</artifactId>
-                <version>${elasticsearch-java-client-version}</version>
+                <version>${elasticsearch-java-client-sniffer-version}</version>
             </dependency>
 
             <!-- Artemis Overrides -->


### PR DESCRIPTION
Use elasticsearch-java-client-sniffer-version for the org.elasticsearch.client artifacts - we do not want productized versions of them.     The org.elasticsearch.clients are from https://github.com/elastic/elasticsearch.git with the elasticsearch-2.0 license.