### PR TITLE
SB Maven plugin add execution

### DIFF
--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/catalog/camel-jbang/spring-boot-pom.tmpl
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/catalog/camel-jbang/spring-boot-pom.tmpl
@@ -86,6 +86,13 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring.boot-version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>com.redhat.camel.springboot.platform</groupId>


### PR DESCRIPTION
Add execution step to the spring boot maven plugin, so that the application can be deployed OOB on OCP