### PR TITLE
Red Hat platform BOM contains ${artemis-version} artifacts - need to add artemis-version to the root pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
 
         <!-- versions -->
         <aether-version>1.0.2.v20150114</aether-version>
+        <artemis-version>2.21.0</artemis-version>
         <arquillian-container-se-managed-version>1.0.2.Final</arquillian-container-se-managed-version>
         <arquillian-version>1.7.0.Alpha10</arquillian-version>
         <asciidoctorj-version>2.5.5</asciidoctorj-version>


### PR DESCRIPTION
We're getting a camel-spring-boot-examples failure on missing artemis-version in the platform bom --
https://orch.psi.redhat.com/pnc-web/#/projects/1137/build-configs/8820/builds/AYMEJEZ3TRQAA/build-log

Need to add <artemis-version> to the root pom.xml