### PR TITLE
[archetype] Update archetype using tag latest

### DIFF
--- a/archetypes/camel-archetype-spring-boot/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/camel-archetype-spring-boot/src/main/resources/archetype-resources/pom.xml
@@ -32,7 +32,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <spring.boot-version>${spring-boot-version}</spring.boot-version>
     <surefire.plugin.version>3.0.0-M4</surefire.plugin.version>
-    <jkube.generator.from>registry.access.redhat.com/ubi8/openjdk-11:1.14</jkube.generator.from>
+    <jkube.generator.from>registry.access.redhat.com/ubi8/openjdk-11:1.15</jkube.generator.from>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
The tag 1.14 has been deprecated and it has C grade [catalog](https://catalog.redhat.com/software/containers/ubi8/openjdk-11/5dd6a4b45a13461646f677f4?tag=1.14-12.1675788288&push_date=1675892157000)
I think the safest way is using `latest` tag to provide always the best image