### PR TITLE
Use camel-version for uses of the camel-netty-http component now that we are productizing it

### DIFF
--- a/components-starter/camel-telegram-starter/pom.xml
+++ b/components-starter/camel-telegram-starter/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-netty-http</artifactId>
-      <version>${camel-community.version}</version>
+      <version>${camel-version}</version>
       <scope>test</scope>
     </dependency>
     <!--START OF GENERATED CODE-->

--- a/components-starter/camel-webhook-starter/pom.xml
+++ b/components-starter/camel-webhook-starter/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-netty-http</artifactId>
-      <version>${camel-community.version}</version>
+      <version>${camel-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -106,7 +106,7 @@
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>artemis-commons</artifactId>
-                <version>${artemis-version}</version>
+                <version>2.26.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>
@@ -117,7 +117,7 @@
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>artemis-core-client</artifactId>
-                <version>${artemis-version}</version>
+                <version>2.26.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.geronimo.specs</groupId>
@@ -128,12 +128,12 @@
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>artemis-jdbc-store</artifactId>
-                <version>${artemis-version}</version>
+                <version>2.26.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>artemis-jms-client</artifactId>
-                <version>${artemis-version}</version>
+                <version>2.26.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.geronimo.specs</groupId>


### PR DESCRIPTION
Previously, camel-netty-http camel-community version was being used for camel-telegram-starter and camel-webhook-starter because we had not productized it.     We should use the camel-version now that it is productized.