### PR TITLE
FTP tests fixes, routes lazy loading, after server config

### DIFF
--- a/components-starter/camel-ftp-starter/src/test/java/org/apache/camel/component/file/remote/springboot/ftps/FileToFtpsImplicitSSLWithClientAuthTest.java
+++ b/components-starter/camel-ftp-starter/src/test/java/org/apache/camel/component/file/remote/springboot/ftps/FileToFtpsImplicitSSLWithClientAuthTest.java
@@ -22,6 +22,8 @@ import org.apache.camel.component.file.remote.springboot.ftp.BaseFtp;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
@@ -31,8 +33,7 @@ import org.springframework.context.annotation.Configuration;
 @SpringBootTest(
         classes = {
                 CamelAutoConfiguration.class,
-                FileToFtpsImplicitSSLWithClientAuthTest.class,
-                FileToFtpsImplicitSSLWithClientAuthTest.TestConfiguration.class
+                FileToFtpsImplicitSSLWithClientAuthTest.class
         }
 )
 //Based on FileToFtpsImplicitSSLWithClientAuthIT
@@ -54,6 +55,11 @@ public class FileToFtpsImplicitSSLWithClientAuthTest extends BaseFtpsImplicitCli
         mock.expectedMessageCount(2);
 
         assertMockEndpointsSatisfied();
+    }
+
+    @BeforeEach
+    public void addRoute() throws Exception {
+        context.addRoutes(new TestConfiguration().routeBuilder());
     }
 
     // *************************************

--- a/components-starter/camel-ftp-starter/src/test/java/org/apache/camel/component/file/remote/springboot/ftps/FileToFtpsWithCustomTrustStorePropertiesTest.java
+++ b/components-starter/camel-ftp-starter/src/test/java/org/apache/camel/component/file/remote/springboot/ftps/FileToFtpsWithCustomTrustStorePropertiesTest.java
@@ -22,6 +22,8 @@ import org.apache.camel.component.file.remote.springboot.ftp.BaseFtp;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
@@ -31,8 +33,7 @@ import org.springframework.context.annotation.Configuration;
 @SpringBootTest(
         classes = {
                 CamelAutoConfiguration.class,
-                FileToFtpsWithCustomTrustStorePropertiesTest.class,
-                FileToFtpsWithCustomTrustStorePropertiesTest.TestConfiguration.class
+                FileToFtpsWithCustomTrustStorePropertiesTest.class
         }
 )
 //based on FileToFtpsWithCustomTrustStorePropertiesIT
@@ -55,6 +56,11 @@ public class FileToFtpsWithCustomTrustStorePropertiesTest extends BaseFtpsClient
         result.expectedMessageCount(2);
 
         assertMockEndpointsSatisfied();
+    }
+
+    @BeforeEach
+    public void addRoute() throws Exception {
+        context.addRoutes(new TestConfiguration().routeBuilder());
     }
 
     // *************************************

--- a/components-starter/camel-ftp-starter/src/test/java/org/apache/camel/component/file/remote/springboot/ftps/FtpsTest.java
+++ b/components-starter/camel-ftp-starter/src/test/java/org/apache/camel/component/file/remote/springboot/ftps/FtpsTest.java
@@ -22,6 +22,8 @@ import org.apache.camel.component.file.remote.springboot.ftp.BaseFtp;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
@@ -31,8 +33,7 @@ import org.springframework.context.annotation.Configuration;
 @SpringBootTest(
         classes = {
                 CamelAutoConfiguration.class,
-                FtpsTest.class,
-                FtpsTest.TestConfiguration.class
+                FtpsTest.class
         }
 )
 //based on FileToFtpsWithCustomTrustStorePropertiesIT
@@ -54,6 +55,11 @@ public class FtpsTest extends BaseFtpsClientAuth {
         result.expectedMessageCount(2);
 
         assertMockEndpointsSatisfied();
+    }
+
+    @BeforeEach
+    public void addRoute() throws Exception {
+        context.addRoutes(new TestConfiguration().routeBuilder());
     }
 
     // *************************************

--- a/components-starter/camel-ftp-starter/src/test/java/org/apache/camel/component/file/remote/springboot/sftp/SftpConsumerLocalWorkDirectoryTest.java
+++ b/components-starter/camel-ftp-starter/src/test/java/org/apache/camel/component/file/remote/springboot/sftp/SftpConsumerLocalWorkDirectoryTest.java
@@ -44,8 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @SpringBootTest(
         classes = {
                 CamelAutoConfiguration.class,
-                SftpConsumerLocalWorkDirectoryTest.class,
-                SftpConsumerLocalWorkDirectoryTest.TestConfiguration.class
+                SftpConsumerLocalWorkDirectoryTest.class
         }
 )
 //Based on SftpConsumerLocalWorkDirectoryIT
@@ -97,6 +96,11 @@ public class SftpConsumerLocalWorkDirectoryTest extends BaseSftp {
 
         // now the lwd file should be deleted
         assertFileNotExists(ftpFile("lwd/hello.txt"));
+    }
+
+    @BeforeEach
+    public void addRoute() throws Exception {
+        context.addRoutes(new TestConfiguration().routeBuilder());
     }
 
     // *************************************

--- a/components-starter/camel-ftp-starter/src/test/java/org/apache/camel/component/file/remote/springboot/sftp/SftpKeyExchangeProtocolsTest.java
+++ b/components-starter/camel-ftp-starter/src/test/java/org/apache/camel/component/file/remote/springboot/sftp/SftpKeyExchangeProtocolsTest.java
@@ -31,6 +31,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -46,8 +47,7 @@ import java.util.List;
 @SpringBootTest(
         classes = {
                 CamelAutoConfiguration.class,
-                SftpKeyExchangeProtocolsTest.class,
-                SftpKeyExchangeProtocolsTest.TestConfiguration.class
+                SftpKeyExchangeProtocolsTest.class
         }
 )
 //Based on SftpKeyExchangeProtocolsIT
@@ -118,6 +118,11 @@ public class SftpKeyExchangeProtocolsTest extends BaseSftp {
                 "a.txt");
 
         result.assertIsSatisfied();
+    }
+
+    @BeforeEach
+    public void addRoute() throws Exception {
+        context.addRoutes(new TestConfiguration().routeBuilder());
     }
 
     // *************************************

--- a/components-starter/camel-ftp-starter/src/test/java/org/apache/camel/component/file/remote/springboot/sftp/SftpUseListFalseTest.java
+++ b/components-starter/camel-ftp-starter/src/test/java/org/apache/camel/component/file/remote/springboot/sftp/SftpUseListFalseTest.java
@@ -25,6 +25,8 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 import org.apache.camel.util.FileUtil;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -41,8 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @SpringBootTest(
         classes = {
                 CamelAutoConfiguration.class,
-                SftpUseListFalseTest.class,
-                SftpUseListFalseTest.TestConfiguration.class
+                SftpUseListFalseTest.class
         }
 )
 //Based on SftpUseListFalseIT
@@ -65,6 +66,11 @@ public class SftpUseListFalseTest extends BaseSftp {
         context.getRouteController().startRoute("foo");
 
         assertMockEndpointsSatisfied();
+    }
+
+    @BeforeEach
+    public void addRoute() throws Exception {
+        context.addRoutes(new TestConfiguration().routeBuilder());
     }
 
     // *************************************


### PR DESCRIPTION
The Spring Boot configuration is executed before the ftp server configuration and the results are wrong route configurations (wrong default ftp server port), due to the ftp server initialization on each test.
Now the failure test classes add the routes to the Camel context before each test, when the ftp server is already configured and the port number is correctly set