### PR TITLE
Removed camel-test-spring as it is not exists in camel 4.

### DIFF
--- a/tooling/camel-spring-boot-bom/pom.xml
+++ b/tooling/camel-spring-boot-bom/pom.xml
@@ -1720,13 +1720,8 @@
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
-        <artifactId>camel-test-spring</artifactId>
-        <version>4.0.0-M3</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-spring-junit5</artifactId>
-        <version>4.0.0-M3</version>
+        <version>${camel-version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomGeneratorMojo.java
+++ b/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomGeneratorMojo.java
@@ -249,13 +249,8 @@ public class BomGeneratorMojo extends AbstractMojo {
         outDependencies.add(dep);
         dep = new Dependency();
         dep.setGroupId("org.apache.camel");
-        dep.setArtifactId("camel-test-spring");
-        dep.setVersion(camelCommunityVersion);
-        outDependencies.add(dep);
-        dep = new Dependency();
-        dep.setGroupId("org.apache.camel");
         dep.setArtifactId("camel-test-spring-junit5");
-        dep.setVersion(camelCommunityVersion);
+        dep.setVersion(camelVersion);
         outDependencies.add(dep);
 
         return outDependencies;


### PR DESCRIPTION
As we are productizing camel-test-spring-junit5, changed the version to productized camel version.