### PR TITLE
CSB-1922 Override snappy-java version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@
         <maven-javadoc-plugin-version>3.4.1</maven-javadoc-plugin-version>
         <maven-surefire-plugin-version>3.1.2</maven-surefire-plugin-version>
         <mycila-license-version>3.0</mycila-license-version>
+        <snappy-java-version>1.1.10.3</snappy-java-version>
         <springdoc-version>1.7.0</springdoc-version>
         <surefire.version>${maven-surefire-plugin-version}</surefire.version>
         <swagger-parser-v3-version>2.1.10</swagger-parser-v3-version>

--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -79,6 +79,12 @@
                 <artifactId>hsqldb</artifactId>
                 <version>${hsqldb-version}</version>
             </dependency>
+            <!-- Override snappy-java -->
+            <dependency>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>${snappy-java-version}</version>
+            </dependency>
             <!-- Overrides undertow-core/servlet since SB is using an older version -->
             <dependency>
                 <groupId>io.undertow</groupId>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -79,6 +79,12 @@
                 <artifactId>hsqldb</artifactId>
                 <version>2.7.2</version>
             </dependency>
+            <!-- Override snappy-java -->
+            <dependency>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>1.1.10.3</version>
+            </dependency>
             <!-- Overrides undertow-core/servlet since SB is using an older version -->
             <dependency>
                 <groupId>io.undertow</groupId>


### PR DESCRIPTION
I think we may want to override this at the camel level as well.