### PR TITLE
CAMEL-19793: update dependencies. (#925)

### DIFF
--- a/components-starter/camel-springdoc-starter/pom.xml
+++ b/components-starter/camel-springdoc-starter/pom.xml
@@ -41,13 +41,8 @@
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>${springdoc-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.swagger.parser.v3</groupId>
-            <artifactId>swagger-parser-v3</artifactId>
-            <version>${swagger-parser-v3-version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>

--- a/components-starter/camel-springdoc-starter/src/main/java/org/apache/camel/springboot/springdoc/SpringdocAutoConfiguration.java
+++ b/components-starter/camel-springdoc-starter/src/main/java/org/apache/camel/springboot/springdoc/SpringdocAutoConfiguration.java
@@ -121,6 +121,7 @@ public class SpringdocAutoConfiguration {
 
         final BeanConfig bc = new BeanConfig();
         final Info info = new Info();
+        bc.setInfo(info);
         final RestConfiguration rc = camelContext.getRestConfiguration();
         Map<String, Object> apiProps = Optional.ofNullable(rc.getApiProperties()).orElseGet(HashMap::new);
         initOpenApi(bc, info, apiProps, 

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <maven-javadoc-plugin-version>3.4.1</maven-javadoc-plugin-version>
         <maven-surefire-plugin-version>3.1.2</maven-surefire-plugin-version>
         <mycila-license-version>3.0</mycila-license-version>
-        <springdoc-version>1.7.0</springdoc-version>
+        <springdoc-version>2.2.0</springdoc-version>
         <surefire.version>${maven-surefire-plugin-version}</surefire.version>
         <swagger-parser-v3-version>2.1.10</swagger-parser-v3-version>
         <cyclonedx-maven-plugin-version>2.7.9</cyclonedx-maven-plugin-version>


### PR DESCRIPTION
Replace springdoc-openapi-ui with springdoc-openapi-starter-webmvc-ui. Update version in the parent pom.
Remove swagger-parser-v3 dependency since it is provided by camel-openapi-java. Fix missing assignment in SpringdocAutoConfiguration.java.