### PR TITLE
Add a netty-bom override

### DIFF
--- a/components-starter/camel-hl7-starter/src/main/docs/hl7.json
+++ b/components-starter/camel-hl7-starter/src/main/docs/hl7.json
@@ -9,7 +9,7 @@
       "name": "camel.dataformat.hl7.customizer",
       "type": "org.apache.camel.spring.boot.DataFormatConfigurationPropertiesCommon$CustomizerProperties",
       "sourceType": "org.apache.camel.component.hl7.springboot.HL7DataFormatConfiguration",
-      "sourceMethod": "public org.apache.camel.spring.boot.DataFormatConfigurationPropertiesCommon.CustomizerProperties getCustomizer() "
+      "sourceMethod": "getCustomizer()"
     },
     {
       "name": "camel.language.hl7terser",
@@ -20,7 +20,7 @@
       "name": "camel.language.hl7terser.customizer",
       "type": "org.apache.camel.spring.boot.LanguageConfigurationPropertiesCommon$CustomizerProperties",
       "sourceType": "org.apache.camel.component.hl7.springboot.Hl7TerserLanguageConfiguration",
-      "sourceMethod": "public org.apache.camel.spring.boot.LanguageConfigurationPropertiesCommon.CustomizerProperties getCustomizer() "
+      "sourceMethod": "getCustomizer()"
     }
   ],
   "properties": [
@@ -39,7 +39,8 @@
       "name": "camel.dataformat.hl7.validate",
       "type": "java.lang.Boolean",
       "description": "Whether to validate the HL7 message Is by default true.",
-      "sourceType": "org.apache.camel.component.hl7.springboot.HL7DataFormatConfiguration"
+      "sourceType": "org.apache.camel.component.hl7.springboot.HL7DataFormatConfiguration",
+      "defaultValue": true
     },
     {
       "name": "camel.language.hl7terser.customizer.enabled",
@@ -68,7 +69,8 @@
       "name": "camel.language.hl7terser.trim",
       "type": "java.lang.Boolean",
       "description": "Whether to trim the value to remove leading and trailing whitespaces and line breaks",
-      "sourceType": "org.apache.camel.component.hl7.springboot.Hl7TerserLanguageConfiguration"
+      "sourceType": "org.apache.camel.component.hl7.springboot.Hl7TerserLanguageConfiguration",
+      "defaultValue": true
     }
   ],
   "hints": []

--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -68,6 +68,16 @@
     <!-- These are place holder dependency management entries -->
     <dependencyManagement>
         <dependencies>
+
+            <!-- Netty bom -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty-version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <!-- Insert third party overrides here -->
             <dependency>
                 <groupId>org.yaml</groupId>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -68,6 +68,16 @@
     <!-- These are place holder dependency management entries -->
     <dependencyManagement>
         <dependencies>
+
+            <!-- Netty bom -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.96.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <!-- Insert third party overrides here -->
             <dependency>
                 <groupId>org.yaml</groupId>


### PR DESCRIPTION
Add a netty-bom override - the versions do not yet match what we want, but we are going to cherry-pick over the netty version commit in camel and the generated bom we produce in the PNC build will be correct once we build.