### PR TITLE
Remove the guava override from 3.20.1 - camel 3 uses a number of different guava versions and we cannot provide a one-size-fits-all guava override

### DIFF
--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -106,12 +106,6 @@
                 <artifactId>undertow-servlet</artifactId>
                 <version>${undertow-version}</version>
             </dependency>
-            <!-- Overrides guava -->
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava-version}</version>
-            </dependency>
             <!-- Overrides avro dependency version since SB's jackson version's takes precedence in camel-jackson-avro-starter -->
             <dependency>
                 <groupId>org.apache.avro</groupId>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -80,7 +80,7 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-bom</artifactId>
-                <version>9.4.50.v20221201</version>
+                <version>9.4.53.v20231009</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -106,17 +106,11 @@
                 <artifactId>undertow-servlet</artifactId>
                 <version>2.2.24.Final</version>
             </dependency>
-            <!-- Overrides guava -->
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava-version}</version>
-            </dependency>
             <!-- Overrides avro dependency version since SB's jackson version's takes precedence in camel-jackson-avro-starter -->
             <dependency>
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro</artifactId>
-                <version>1.11.1</version>
+                <version>1.11.3</version>
             </dependency>
             <!-- Override commons-compress version -->
             <dependency>


### PR DESCRIPTION
Remove the guava override from 3.20.1 - camel 3 uses a number of different guava versions and we cannot provide a one-size-fits-all guava override