### PR TITLE
Update commons-io version used in test to the one used in camel-parent (2.11.0)

### DIFF
--- a/tooling/redhat-patch-maven-plugin/src/test/java/org/apache/camel/springboot/patch/MavenTest.java
+++ b/tooling/redhat-patch-maven-plugin/src/test/java/org/apache/camel/springboot/patch/MavenTest.java
@@ -127,7 +127,7 @@ public class MavenTest {
         session.setLocalRepositoryManager(resolverSystem.newLocalRepositoryManager(session, localRepository));
 
         ArtifactRequest request = new ArtifactRequest();
-        request.setArtifact(new DefaultArtifact("commons-io:commons-io:jar:2.8.0"));
+        request.setArtifact(new DefaultArtifact("commons-io:commons-io:jar:2.11.0"));
         ArtifactResult result = resolverSystem.resolveArtifact(session, request);
         System.out.println(result.getArtifact().getFile());
     }


### PR DESCRIPTION
On CI, we're failing MavenTest on commons-io:commons-io:2.8.0 - I'm not exactly sure why this is failing but, I'm going to try to patch it by upgrading the version of commons-io to the version being used in camel-parent.