### PR TITLE
Add an entry for patch-maven-plugin

### DIFF
--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -237,4 +237,15 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.redhat.camel.springboot.platform</groupId>
+                    <artifactId>patch-maven-plugin</artifactId>
+                    <version>${maven-javadoc-plugin-version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>


### PR DESCRIPTION
Add an entry for patch-maven-plugin - think this will solve the issue of plexus-utils not being contained in the MRRC

I think the only way I can really test this is to commit it and then rebuild the MRRC, then try rebuilding against that MRRC / check for plexus-utils.