### PR TITLE
Fix snyk SAST ZipWagon errors

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2,3 +2,4 @@ exclude:
     global:
         - "*IT.java"
         - "*Test.java"
+        - "*src/test*"

--- a/tooling/redhat-patch-maven-plugin/src/main/java/org/apache/camel/springboot/patch/extensions/ZipWagon.java
+++ b/tooling/redhat-patch-maven-plugin/src/main/java/org/apache/camel/springboot/patch/extensions/ZipWagon.java
@@ -39,6 +39,7 @@ import java.util.Enumeration;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
 import org.apache.maven.MavenExecutionException;
@@ -94,6 +95,14 @@ public class ZipWagon extends StreamWagon {
                 if (ze.isDirectory()) {
                     continue;
                 }
+
+                String canonicalPath = tmpDir.getCanonicalPath();
+                File destFile = new File(tmpDir, ze.getName());
+                String canonicalDestinationFile =  destFile.getCanonicalPath();
+                if (!canonicalDestinationFile.startsWith(canonicalPath + File.separator)) {
+                    throw new ZipException("Archive entry is outside of the target directory path : " + ze.getName());
+                }
+
                 String name = trimName(ze.getName());
                 File target = new File(tmpDir, name);
                 if ("maven-metadata-local.xml".equals(target.getName())) {


### PR DESCRIPTION
Fix Zip SAST errors in patch-maven-plugin by adding a check that the entry is within the target path