### PR TITLE
Add a dependency for patch-maven-plugin

### DIFF
--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -199,6 +199,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>com.redhat.camel.springboot.platform</groupId>
+                <artifactId>patch-maven-plugin</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <build>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -199,6 +199,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>com.redhat.camel.springboot.platform</groupId>
+                <artifactId>patch-maven-plugin</artifactId>
+                <version>3.20.1-SNAPSHOT</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <build>


### PR DESCRIPTION
Getting a failure in generating the MRRC --

11:20:29  [ERROR] - Failed to generate Maven repository using RESOLVE_ONLY, Error: io.quarkus.bootstrap.resolver.maven.BootstrapMavenException: Failed to resolve dependencies for Maven plugin com.redhat.camel.springboot.platform:patch-maven-plugin:jar:3.20.1.redhat-00001

I'd like to utilize the ability of extensionsArtifactList to figure out the version of the spring boot dependencies by setting all of the entries to 3.20.1.redhat-00001 and having MRRC choose the correct version - I think we are getting this error because patch-maven-plugin doesn't appear in any of the boms as a dependency.   I'd like to try to add it and see if that fixes the problem.