### PR TITLE
Add repository/pluginRepository entries to archetype

### DIFF
--- a/archetypes/camel-archetype-spring-boot/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/camel-archetype-spring-boot/src/main/resources/archetype-resources/pom.xml
@@ -95,6 +95,34 @@
     </dependency>
   </dependencies>
 
+  <repositories>
+    <repository>
+      <id>redhat-ga</id>
+      <url>https://maven.repository.redhat.com/ga/</url>
+      <name>Red Hat GA repository</name>
+      <snapshots>
+          <enabled>false</enabled>
+      </snapshots>
+      <releases>
+          <enabled>true</enabled>
+      </releases>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>redhat-ga</id>
+      <url>https://maven.repository.redhat.com/ga/</url>
+      <name>Red Hat GA repository</name>
+      <snapshots>
+          <enabled>false</enabled>
+      </snapshots>
+      <releases>
+          <enabled>true</enabled>
+      </releases>
+    </pluginRepository>
+  </pluginRepositories>
+
+
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
This came up in the Fuse Camel chat room that the app produced by the archetype is missing the Red Hat GA repository as a repository/pluginRepository - I think this solves the issue. 

I am not sure how our most recent documentation covers this.

`mvn package test
[INFO] Scanning for projects...
Downloading from central: https://repo.maven.apache.org/maven2/com/redhat/camel/springboot/platform/patch-maven-plugin/4.0.0.redhat-00036/patch-maven-plugin-4.0.0.redhat-00036.pom
[WARNING] The POM for com.redhat.camel.springboot.platform:patch-maven-plugin:jar:4.0.0.redhat-00036 is missing, no dependency information available
Downloading from central: https://repo.maven.apache.org/maven2/com/redhat/camel/springboot/platform/patch-maven-plugin/4.0.0.redhat-00036/patch-maven-plugin-4.0.0.redhat-00036.jar
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[ERROR] Unresolveable build extension: Plugin com.redhat.camel.springboot.platform:patch-maven-plugin:4.0.0.redhat-00036 or one of its dependencies could not be resolved: Could not find artifact com.redhat.camel.springboot.platform:patch-maven-plugin:jar:4.0.0.redhat-00036 in central (https://repo.maven.apache.org/maven2) @ 
 @ `

