### PR TITLE
Add dependencyManagement entries for artifacts being overwritten in redhat BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,41 @@
                 <artifactId>openshift-maven-plugin</artifactId>
                 <version>${openshift-maven-plugin-version}</version>
             </dependency>
+            <!-- org.apache.tomcat:catalina dependencyManagement entry
+                is necessary for PME align to the correct tomcat-version -->
+            <dependency>
+                <groupId>org.apache.tomcat</groupId>
+                <artifactId>tomcat-catalina</artifactId>
+                <version>${tomcat-version}</version>
+            </dependency>
+            <!-- io.projectreactor.netty:reactor-netty-http dependencyManagement entry
+                is necessary for PME align to the correct reactor-netty-version -->
+            <dependency>
+                <groupId>io.projectreactor.netty</groupId>
+                <artifactId>reactor-netty-http</artifactId>
+                <version>${reactor-netty-version}</version>
+            </dependency>
+            <!-- org.json:json dependencyManagement entry
+                is necessary for PME align to the correct org-json-json-version -->
+            <dependency>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+                <version>${org-json-json-version}</version>
+            </dependency>
+
+            <!-- org.apache.activemq:artemis-version dependencyManagement entry
+                is necessary for PME align to the correct artemis-version -->
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-commons</artifactId>
+                <version>${artemis-version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -4055,6 +4055,11 @@
         <version>3.6.4</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-catalina</artifactId>
+        <version>10.1.16</version>
+      </dependency>
+      <dependency>
         <groupId>org.codehaus.jackson</groupId>
         <artifactId>jackson-core-asl</artifactId>
         <version>${jackson-version}</version>
@@ -4088,6 +4093,11 @@
         <groupId>org.fusesource</groupId>
         <artifactId>camel-sap-starter</artifactId>
         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.json</groupId>
+        <artifactId>json</artifactId>
+        <version>20231013</version>
       </dependency>
       <dependency>
         <groupId>org.xerial.snappy</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/CSB-3222

For the redhat-camel-spring-boot-bom, we depend on PME aligning the camel-spring-boot root pom.xml (org.apache.camel.springboot:spring-boot).     The redhat-camel-spring-boot-bom-generator takes those versions at runtime and regenerates the redhat-camel-spring-boot-bom.

For this to work, we need dependencyManagement entries for any version property that needs to be listed in org.apache.camel.springboot:spring-boot.     Otherwise, PME will not align the version properties in org.apache.camel.springboot:spring-boot and we will not get the correct versions in the BOM generation.