### PR TITLE
Change non-productized camel components to camel-community.version

### DIFF
--- a/components-starter/camel-hl7-starter/pom.xml
+++ b/components-starter/camel-hl7-starter/pom.xml
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-mina</artifactId>
-      <version>${camel-version}</version>
+      <version>${camel-community.version}</version>
       <scope>test</scope>
     </dependency>
     <!--START OF GENERATED CODE-->

--- a/components-starter/camel-kamelet-starter/pom.xml
+++ b/components-starter/camel-kamelet-starter/pom.xml
@@ -66,13 +66,13 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-groovy</artifactId>
-      <version>${camel-version}</version>
+      <version>${camel-community.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-joor</artifactId>
-      <version>${camel-version}</version>
+      <version>${camel-community.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/components-starter/camel-telegram-starter/pom.xml
+++ b/components-starter/camel-telegram-starter/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-netty-http</artifactId>
-      <version>${camel-version}</version>
+      <version>${camel-community.version}</version>
       <scope>test</scope>
     </dependency>
     <!--START OF GENERATED CODE-->

--- a/components-starter/camel-webhook-starter/pom.xml
+++ b/components-starter/camel-webhook-starter/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-netty-http</artifactId>
-      <version>${camel-version}</version>
+      <version>${camel-community.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Cherry pick commit over from 4.0.0-branch that uses community version for non-productized camel components