### PR TITLE
Set camel-groovy / camel-netty-http to productized camel versions

### DIFF
--- a/components-starter/camel-kamelet-starter/pom.xml
+++ b/components-starter/camel-kamelet-starter/pom.xml
@@ -66,13 +66,13 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-groovy</artifactId>
-      <version>${camel-community.version}</version>
+      <version>${camel-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-joor</artifactId>
-      <version>${camel-community.version}</version>
+      <version>${camel-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/components-starter/camel-telegram-starter/pom.xml
+++ b/components-starter/camel-telegram-starter/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-netty-http</artifactId>
-      <version>${camel-community.version}</version>
+      <version>${camel-version}</version>
       <scope>test</scope>
     </dependency>
     <!--START OF GENERATED CODE-->

--- a/components-starter/camel-webhook-starter/pom.xml
+++ b/components-starter/camel-webhook-starter/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-netty-http</artifactId>
-      <version>${camel-community.version}</version>
+      <version>${camel-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
The artifacts here (camel-groovy / camel-netty) are productized in the 4.4.0 product build - need to be using the productized versions.