### PR TITLE
Remove the SB BOM since it is present in the platform

### DIFF
--- a/archetypes/camel-archetype-spring-boot/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/camel-archetype-spring-boot/src/main/resources/archetype-resources/pom.xml
@@ -47,14 +47,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!-- Spring Boot BOM -->
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring.boot-version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
The SB BOM is not needed, it is not present in 4.0.0 version either.