### PR TITLE
Removal of sshd-scp dependency - not needed

### DIFF
--- a/components-starter/camel-ftp-starter/pom.xml
+++ b/components-starter/camel-ftp-starter/pom.xml
@@ -65,12 +65,6 @@
       <version>${sshd-version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.sshd</groupId>
-      <artifactId>sshd-scp</artifactId>
-      <version>${sshd-version}</version>
-      <scope>test</scope>
-    </dependency>
     <!-- for testing sftp through http proxy -->
     <dependency>
       <groupId>org.littleshoot</groupId>

--- a/components-starter/camel-ftp-starter/src/test/java/org/apache/camel/component/file/remote/springboot/sftp/SftpEmbeddedService.java
+++ b/components-starter/camel-ftp-starter/src/test/java/org/apache/camel/component/file/remote/springboot/sftp/SftpEmbeddedService.java
@@ -26,7 +26,6 @@ import org.apache.sshd.common.keyprovider.FileKeyPairProvider;
 import org.apache.sshd.common.session.helpers.AbstractSession;
 import org.apache.sshd.common.signature.BuiltinSignatures;
 import org.apache.sshd.common.signature.Signature;
-import org.apache.sshd.scp.server.ScpCommandFactory;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator;
 import org.apache.sshd.sftp.server.SftpSubsystemFactory;
@@ -82,7 +81,6 @@ public class SftpEmbeddedService extends AbstractTestService implements FtpServi
         sshd.setPort(port);
         sshd.setKeyPairProvider(new FileKeyPairProvider(Paths.get("src/test/resources/hostkey.pem")));
         sshd.setSubsystemFactories(Collections.singletonList(new SftpSubsystemFactory()));
-        sshd.setCommandFactory(new ScpCommandFactory());
         sshd.setPasswordAuthenticator((username, password, session) -> true);
         sshd.setPublickeyAuthenticator(getPublickeyAuthenticator());
 


### PR DESCRIPTION
I'd like to remove the sshd-scp test dependency - I've done some testing and I don't think it is needed.    

- it exists only to set a default ScpCommandFactory()
- all of the sftp tests are excluded
- tests pass without it on my machine (12 tests are run, 0 failures, 0 errors)
- same results with it (12 tests are run, 0 failures, 0 errors)
- if I remove the exclusions on sftp tests, I get the same test results with it and without it (three tests in SftpSimpleProduceThroughProxyTest fail)

This dependency is causing some issues in productization and since it doesn't seem useful and all of the tests which utilize it are excluded, it seems like we should just remove it.