### PR TITLE
CSB-3797 Change version of stax2-api to 4.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,7 @@
         <cyclonedx-maven-plugin-version>2.7.11</cyclonedx-maven-plugin-version>
         <tomcat-version>10.1.19</tomcat-version>
         <snappy-java-version>1.1.10.4</snappy-java-version>
+        <woodstox-stax2-api-version>4.2.1</woodstox-stax2-api-version>
 
         <!-- Added for productized build - plexus versions used by patch maven plugin -->
         <openshift-maven-plugin-version>1.16.1.redhat-00003</openshift-maven-plugin-version>

--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -309,7 +309,7 @@
             <dependency>
                 <groupId>org.codehaus.woodstox</groupId>
                 <artifactId>stax2-api</artifactId>
-                <version>${woodstox-version}</version>
+                <version>${woodstox-stax2-api-version}</version>
             </dependency>
 
             <dependency>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -309,7 +309,7 @@
             <dependency>
                 <groupId>org.codehaus.woodstox</groupId>
                 <artifactId>stax2-api</artifactId>
-                <version>4.4.1</version>
+                <version>4.2.1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Was using 4.4.1 which doesn't exist https://mvnrepository.com/artifact/org.codehaus.woodstox/stax2-api

Using 4.2.1 as in Doc

https://issues.redhat.com/browse/CSB-3797

Thanks !

cc @cunningt 