### PR TITLE
CSB-3601: fix dependency convergence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@
         <arquillian-container-se-managed-version>1.0.2.Final</arquillian-container-se-managed-version>
         <arquillian-version>1.7.0.Alpha10</arquillian-version>
         <avro-version>1.11.3</avro-version>
+        <findbugs-version>3.0.2.redhat-00017</findbugs-version>
         <groovy-version>4.0.18</groovy-version>
         <graal-sdk-version>22.3.2</graal-sdk-version>
         <jakarta-jaxb-version>4.0.0</jakarta-jaxb-version>

--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -307,6 +307,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>${findbugs-version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.codehaus.woodstox</groupId>
                 <artifactId>stax2-api</artifactId>
                 <version>${woodstox-stax2-api-version}</version>
@@ -485,10 +491,20 @@
                 <artifactId>swagger-models-jakarta</artifactId>
                 <version>${swagger-openapi3-version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-core-jakarta</artifactId>
+                <version>${swagger-openapi3-version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>io.swagger.parser.v3</groupId>
                 <artifactId>swagger-parser</artifactId>
+                <version>${swagger-openapi3-java-parser-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger.parser.v3</groupId>
+                <artifactId>swagger-parser-v3</artifactId>
                 <version>${swagger-openapi3-java-parser-version}</version>
             </dependency>
 

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -307,6 +307,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>3.0.2.redhat-00017</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.codehaus.woodstox</groupId>
                 <artifactId>stax2-api</artifactId>
                 <version>4.2.1</version>
@@ -485,10 +491,20 @@
                 <artifactId>swagger-models-jakarta</artifactId>
                 <version>2.2.20.redhat-00001</version>
             </dependency>
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-core-jakarta</artifactId>
+                <version>2.2.20.redhat-00001</version>
+            </dependency>
 
             <dependency>
                 <groupId>io.swagger.parser.v3</groupId>
                 <artifactId>swagger-parser</artifactId>
+                <version>2.1.20.redhat-00001</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger.parser.v3</groupId>
+                <artifactId>swagger-parser-v3</artifactId>
                 <version>2.1.20.redhat-00001</version>
             </dependency>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/CSB-3601

Set dependency versions for findbugs:jsr305, swagger-core-jakarta and swagger-parser-v3.

This is done in order to resolve dependency alignment issues between `cxf-rt-rs-service-description-openapi-v3` and `camel-openapi-java-starter`

Thanks !