### PR TITLE
Add override on threetenbp

### DIFF
--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -261,6 +261,11 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>org.threeten</groupId>
+                <artifactId>threetenbp</artifactId>
+                <version>${threetenbp-version}</version>
+            </dependency>
 
             <!-- Netty bom -->
             <dependency>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -261,6 +261,11 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>org.threeten</groupId>
+                <artifactId>threetenbp</artifactId>
+                <version>${threetenbp-version}</version>
+            </dependency>
 
             <!-- Netty bom -->
             <dependency>


### PR DESCRIPTION
threetenbp is showing up in the quido results - it is overridden at the camel level but we should also add a bom override as well