### PR TITLE
CSB-3222 Use activemq-artemis-version from camel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,6 @@
         <!-- versions -->
         <aalto-xml-version>1.3.2</aalto-xml-version>
         <aether-version>1.0.2.v20150114</aether-version>
-        <artemis-version>2.32.0</artemis-version>
         <arquillian-container-se-managed-version>1.0.2.Final</arquillian-container-se-managed-version>
         <arquillian-version>1.7.0.Alpha10</arquillian-version>
         <avro-version>1.11.3</avro-version>
@@ -267,20 +266,6 @@
                 <groupId>jakarta.resource</groupId>
                 <artifactId>jakarta.resource-api</artifactId>
                 <version>${jakarta-resource-version}</version>
-            </dependency>
-
-            <!-- org.apache.activemq:artemis-version dependencyManagement entry
-                is necessary for PME align to the correct artemis-version -->
-            <dependency>
-                <groupId>org.apache.activemq</groupId>
-                <artifactId>artemis-commons</artifactId>
-                <version>${artemis-version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
         </dependencies>

--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -221,7 +221,7 @@
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>artemis-commons</artifactId>
-                <version>${artemis-version}</version>
+                <version>${activemq-artemis-version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>
@@ -232,7 +232,7 @@
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>artemis-core-client</artifactId>
-                <version>${artemis-version}</version>
+                <version>${activemq-artemis-version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.geronimo.specs</groupId>
@@ -243,17 +243,17 @@
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>artemis-jakarta-client</artifactId>
-                <version>${artemis-version}</version>
+                <version>${activemq-artemis-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>artemis-jdbc-store</artifactId>
-                <version>${artemis-version}</version>
+                <version>${activemq-artemis-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>artemis-jms-client</artifactId>
-                <version>${artemis-version}</version>
+                <version>${activemq-artemis-version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.geronimo.specs</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/CSB-3222 

We should be using activemq-artemis-version from camel-parent here.