### PR TITLE
CSB-5313:artemis-quorum-api was removed in artemis 2.33+ in favor of …

### DIFF
--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -260,7 +260,7 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
-                <artifactId>artemis-quorum-api</artifactId>
+                <artifactId>artemis-lockmanager-api</artifactId>
                 <version>${activemq-artemis-version}</version>
             </dependency>
             <dependency>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -260,7 +260,7 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
-                <artifactId>artemis-quorum-api</artifactId>
+                <artifactId>artemis-lockmanager-api</artifactId>
                 <version>2.33.0.redhat-00013</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
…artemis-lockmanager.