### PR TITLE
Manages undertow-websockets-jsr

### DIFF
--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -92,6 +92,11 @@
                 <artifactId>undertow-servlet</artifactId>
                 <version>2.3.17.Final</version>
             </dependency>
+            <dependency>
+                <groupId>io.undertow</groupId>
+                <artifactId>undertow-websockets-jsr</artifactId>
+                <version>2.3.17.Final</version>
+            </dependency>
             <!-- Overrides guava -->
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
since `undertow-websockets-jsr` is a part of the transitive dependencies of `org.springframework.boot:spring-boot-starter-undertow`