### PR TITLE
Use productized versions of camel/fuse-components

### DIFF
--- a/components-starter/camel-hl7-starter/pom.xml
+++ b/components-starter/camel-hl7-starter/pom.xml
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-mina</artifactId>
-      <version>${camel-version}</version>
+      <version>${camel-community.version}</version>
       <scope>test</scope>
     </dependency>
     <!--START OF GENERATED CODE-->

--- a/components-starter/pom.xml
+++ b/components-starter/pom.xml
@@ -270,7 +270,7 @@
     <!-- <module>camel-jcache-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-jcr-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <module>camel-jdbc-starter</module>
-    <module>camel-jetty-starter</module>
+    <!-- <module>camel-jetty-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-jfr-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-jgroups-cluster-service-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-jgroups-raft-cluster-service-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->

--- a/maintenance/pom.xml
+++ b/maintenance/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>spring-boot-parent</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/maintenance/redhat-camel-spring-boot-patch-metadata/pom.xml
+++ b/maintenance/redhat-camel-spring-boot-patch-metadata/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.redhat.camel.springboot.platform</groupId>
         <artifactId>redhat-camel-spring-boot-maintenance</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>redhat-camel-spring-boot-patch-metadata</artifactId>

--- a/maintenance/redhat-camel-spring-boot-patch-repository/pom.xml
+++ b/maintenance/redhat-camel-spring-boot-patch-repository/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.redhat.camel.springboot.platform</groupId>
         <artifactId>redhat-camel-spring-boot-maintenance</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>redhat-camel-spring-boot-patch-repository</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dependencies</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
     </parent>
 
     <groupId>org.apache.camel.springboot</groupId>
@@ -113,15 +113,15 @@
         <spring-boot-version>3.3.3</spring-boot-version>
 
         <!-- Camel target version -->
-        <camel-version>4.8.0</camel-version>
+        <camel-version>4.8.0.redhat-00001</camel-version>
 
         <!-- cq plugin version -->
         <cq-plugin.version>4.4.11</cq-plugin.version>
         <camel-community.version>4.8.0</camel-community.version>
         <camel-spring-boot-community.version>4.8.0</camel-spring-boot-community.version>
 
-        <camel-sap.version>4.4.0.redhat-00016</camel-sap.version>
-        <camel-cics.version>4.4.0.redhat-00016</camel-cics.version>
+        <camel-sap.version>4.8.0.redhat-00001</camel-sap.version>
+        <camel-cics.version>4.8.0.redhat-00001</camel-cics.version>
         <!-- narayana spring boot version -->
         <narayana-spring-boot.version>3.0.0.redhat-00017</narayana-spring-boot.version>
 

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -290,17 +290,17 @@
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-debezium-maven-plugin</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-salesforce-maven-plugin</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-servicenow-maven-plugin</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -2140,7 +2140,7 @@
       <dependency>
         <groupId>org.apache.camel.tests</groupId>
         <artifactId>org.apache.camel.tests.mock-javamail_1.7</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2155,18 +2155,18 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-allcomponents</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-amqp</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-api</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2206,12 +2206,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-attachments</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-avro</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2261,12 +2261,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-cw</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ddb</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2296,7 +2296,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-kinesis</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2306,7 +2306,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-lambda</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2326,7 +2326,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-s3</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2336,12 +2336,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sns</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sqs</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2371,7 +2371,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-eventhubs</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2391,12 +2391,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-servicebus</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-blob</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2406,7 +2406,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-queue</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2416,12 +2416,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base-engine</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2431,22 +2431,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean-validator</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-beanio</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bindy</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2471,7 +2471,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-browse</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2481,22 +2481,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cassandraql</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog-console</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog-lucene</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2521,22 +2521,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cli-connector</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloud</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloudevents</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cluster</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2556,12 +2556,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-componentdsl</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-console</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2571,12 +2571,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-controlbus</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2587,37 +2587,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-catalog</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-engine</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-languages</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-model</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-processor</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-reifier</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-xml</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2632,12 +2632,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cron</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-crypto</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2662,52 +2662,52 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-common</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-rest</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-soap</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-common</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-rest</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-soap</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-transport</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-transport</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataformat</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataset</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2772,7 +2772,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-direct</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2807,12 +2807,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-modeline</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-support</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2827,7 +2827,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2842,12 +2842,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl-support</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2867,17 +2867,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir-api</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-file</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2892,7 +2892,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-flink</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2907,7 +2907,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ftp</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2927,7 +2927,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-bigquery</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2952,7 +2952,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-pubsub</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2992,7 +2992,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-groovy</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3007,12 +3007,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-grpc</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-gson</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3037,27 +3037,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-health</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hl7</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-base</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-common</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3117,17 +3117,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-common</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-embedded</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3152,32 +3152,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-avro</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-protobuf</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jacksonxml</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jasypt</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-java-joor-dsl</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3187,7 +3187,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jaxb</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3232,7 +3232,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jdbc</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3247,7 +3247,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jfr</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3262,12 +3262,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jira</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jms</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3287,12 +3287,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-joor</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jpa</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3317,7 +3317,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jslt</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3347,17 +3347,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonpath</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jt400</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jta</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3367,32 +3367,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kafka</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet-main</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-api</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-http</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3407,12 +3407,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kubernetes</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kudu</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3447,12 +3447,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-language</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ldap</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3467,12 +3467,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-log</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lra</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3492,37 +3492,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail-microsoft-oauth</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-main</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management-api</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mapstruct</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-master</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3532,7 +3532,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-micrometer</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3542,17 +3542,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-config</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-fault-tolerance</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-health</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3567,22 +3567,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-minio</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mllp</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mock</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mongodb</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3602,22 +3602,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mybatis</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nats</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty-http</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3652,22 +3652,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4-api</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-java</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-rest-dsl-generator</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3687,7 +3687,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opentelemetry</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3697,12 +3697,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho-mqtt5</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3732,7 +3732,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3742,12 +3742,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-main</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-vertx</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3787,7 +3787,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-quartz</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3822,7 +3822,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ref</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3832,7 +3832,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-resilience4j</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3842,12 +3842,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest-openapi</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3877,12 +3877,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saga</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-salesforce</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3897,12 +3897,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saxon</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-scheduler</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3912,7 +3912,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-seda</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3927,7 +3927,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-servlet</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3947,12 +3947,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-slack</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smb</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3972,12 +3972,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-snmp</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-soap</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3987,67 +3987,67 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk-hec</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-batch</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-jdbc</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-ldap</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-main</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-rabbitmq</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-redis</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-security</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-ws</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-xml</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sql</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4082,12 +4082,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stub</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-support</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4112,17 +4112,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-telegram</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-junit5</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4132,7 +4132,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-spring-junit5</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4157,27 +4157,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-timer</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-maven</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-model</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-util</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tracing</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4192,12 +4192,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-undertow</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-undertow-spring-security</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4207,22 +4207,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util-json</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-validator</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-velocity</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4232,17 +4232,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-common</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-http</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-websocket</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4267,7 +4267,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-webhook</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4292,27 +4292,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xj</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-dsl</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-util</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxb</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4322,12 +4322,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp-util</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4342,37 +4342,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xpath</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt-saxon</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-common</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-deserializers</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-io</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4387,12 +4387,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zip-deflater</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zipfile</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4412,7 +4412,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>spi-annotations</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
@@ -4452,7 +4452,7 @@
       <dependency>
         <groupId>org.fusesource</groupId>
         <artifactId>camel-cics</artifactId>
-        <version>4.4.0.redhat-00016</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.fusesource</groupId>
@@ -4462,7 +4462,7 @@
       <dependency>
         <groupId>org.fusesource</groupId>
         <artifactId>camel-sap</artifactId>
-        <version>4.4.0.redhat-00016</version>
+        <version>4.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.fusesource</groupId>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -167,13 +167,13 @@
             <dependency>
                 <groupId>org.mvel</groupId>
                 <artifactId>mvel2</artifactId>
-                <version>2.5.2.Final</version>
+                <version>2.5.2.Final-redhat-00001</version>
             </dependency>
             <!-- Overrides json-path dependency -->
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path</artifactId>
-                <version>2.9.0</version>
+                <version>2.9.0.redhat-00001</version>
             </dependency>
             <!-- Overrides avro dependency version since SB's jackson version's takes precedence in camel-jackson-avro-starter -->
             <dependency>
@@ -214,7 +214,7 @@
             <dependency>
                 <groupId>org.eclipse.angus</groupId>
                 <artifactId>angus-mail</artifactId>
-                <version>2.0.3</version>
+                <version>2.0.3.redhat-00001</version>
             </dependency>
 
             <!-- overrides for ca.uhn.hapi.fhir:org.hl7.fhir.* -->
@@ -350,14 +350,14 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.112.Final</version>
+                <version>4.1.112.Final-redhat-00001</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-bom</artifactId>
-                <version>12.0.12</version>
+                <version>12.0.12.redhat-00002</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -365,7 +365,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.17.2</version>
+                <version>2.17.2.redhat-00001</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -373,7 +373,7 @@
             <dependency>
                 <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-bom</artifactId>
-                <version>15.0.8.Final</version>
+                <version>15.0.8.Final-redhat-00001</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -388,7 +388,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.16.1</version>
+                <version>2.16.1.redhat-00001</version>
             </dependency>
 
             <dependency>
@@ -412,13 +412,13 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.14</version>
+                <version>4.5.14.redhat-00012</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient-cache</artifactId>
-                <version>4.5.14</version>
+                <version>4.5.14.redhat-00012</version>
             </dependency>
 
             <dependency>
@@ -454,7 +454,7 @@
             <dependency>
                 <groupId>jakarta.inject</groupId>
                 <artifactId>jakarta.inject</artifactId>
-                <version>2.0.1</version>
+                <version>2.0.1.redhat-00005</version>
             </dependency>
 
             <dependency>
@@ -466,7 +466,7 @@
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.12.7</version>
+                <version>2.12.7.redhat-00002</version>
             </dependency>
 
             <dependency>
@@ -520,7 +520,7 @@
             <dependency>
                 <groupId>org.apache.qpid</groupId>
                 <artifactId>proton-j</artifactId>
-                <version>0.34.1</version>
+                <version>0.34.1.redhat-00002</version>
             </dependency>
 
             <dependency>
@@ -532,7 +532,7 @@
             <dependency>
                 <groupId>org.jasypt</groupId>
                 <artifactId>jasypt</artifactId>
-                <version>1.9.3</version>
+                <version>1.9.3.redhat-00004</version>
             </dependency>
 
             <dependency>
@@ -611,7 +611,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-bom</artifactId>
-                <version>4.0.5</version>
+                <version>4.0.5.redhat-00001</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
There's a couple of other minor tweaks in here like

- remove camel-jetty-starter (not sure why it was included for productization, we don't build it in 4.4.0 : https://github.com/jboss-fuse/camel-spring-boot/blob/camel-spring-boot-4.4.0-branch/components-starter/pom.xml#L266)
- use community version of mina (we do the same in 4.4.0)
- maintenance versions should be 4.8.0-SNAPSHOT