### PR TITLE
Change ${hapi-fhir-core.version} -> ${hapi-fhir-core-version}; sync-properties-maven-plugin in camel does not seem to deal with properties with a "." in them

### DIFF
--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -221,32 +221,32 @@
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>org.hl7.fhir.dstu2</artifactId>
-                <version>${hapi-fhir-core.version}</version>
+                <version>${hapi-fhir-core-version}</version>
             </dependency>
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>org.hl7.fhir.dstu2016may</artifactId>
-                <version>${hapi-fhir-core.version}</version>
+                <version>${hapi-fhir-core-version}</version>
             </dependency>
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>org.hl7.fhir.dstu3</artifactId>
-                <version>${hapi-fhir-core.version}</version>
+                <version>${hapi-fhir-core-version}</version>
             </dependency>
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>org.hl7.fhir.r4</artifactId>
-                <version>${hapi-fhir-core.version}</version>
+                <version>${hapi-fhir-core-version}</version>
             </dependency>
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>org.hl7.fhir.r4b</artifactId>
-                <version>${hapi-fhir-core.version}</version>
+                <version>${hapi-fhir-core-version}</version>
             </dependency>
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>org.hl7.fhir.r5</artifactId>
-                <version>${hapi-fhir-core.version}</version>
+                <version>${hapi-fhir-core-version}</version>
                 <exclusions>
                 <exclusion>
                     <groupId>com.github.stephenc.jcip</groupId>
@@ -257,7 +257,7 @@
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>org.hl7.fhir.utilities</artifactId>
-                <version>${hapi-fhir-core.version}</version>
+                <version>${hapi-fhir-core-version}</version>
             </dependency>
 
             <!-- upgrades for spring -->

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -221,32 +221,32 @@
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>org.hl7.fhir.dstu2</artifactId>
-                <version>${hapi-fhir-core.version}</version>
+                <version>${hapi-fhir-core-version}</version>
             </dependency>
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>org.hl7.fhir.dstu2016may</artifactId>
-                <version>${hapi-fhir-core.version}</version>
+                <version>${hapi-fhir-core-version}</version>
             </dependency>
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>org.hl7.fhir.dstu3</artifactId>
-                <version>${hapi-fhir-core.version}</version>
+                <version>${hapi-fhir-core-version}</version>
             </dependency>
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>org.hl7.fhir.r4</artifactId>
-                <version>${hapi-fhir-core.version}</version>
+                <version>${hapi-fhir-core-version}</version>
             </dependency>
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>org.hl7.fhir.r4b</artifactId>
-                <version>${hapi-fhir-core.version}</version>
+                <version>${hapi-fhir-core-version}</version>
             </dependency>
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>org.hl7.fhir.r5</artifactId>
-                <version>${hapi-fhir-core.version}</version>
+                <version>${hapi-fhir-core-version}</version>
                 <exclusions>
                 <exclusion>
                     <groupId>com.github.stephenc.jcip</groupId>
@@ -257,7 +257,7 @@
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>org.hl7.fhir.utilities</artifactId>
-                <version>${hapi-fhir-core.version}</version>
+                <version>${hapi-fhir-core-version}</version>
             </dependency>
 
             <!-- upgrades for spring -->


### PR DESCRIPTION
Change ${hapi-fhir-core.version} -> ${hapi-fhir-core-version}; sync-properties-maven-plugin in camel does not seem to deal with properties with a "." in them