### PR TITLE
Remove threetenbp override

### DIFF
--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -339,13 +339,6 @@
                 <version>${activemq-artemis-version}</version>
             </dependency>
 
-            <!-- threetenbp -->
-            <dependency>
-                <groupId>org.threeten</groupId>
-                <artifactId>threetenbp</artifactId>
-                <version>${threetenbp-version}</version>
-            </dependency>
-
             <!-- Netty bom -->
             <dependency>
                 <groupId>io.netty</groupId>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -339,13 +339,6 @@
                 <version>2.37.0</version>
             </dependency>
 
-            <!-- threetenbp -->
-            <dependency>
-                <groupId>org.threeten</groupId>
-                <artifactId>threetenbp</artifactId>
-                <version>${threetenbp-version}</version>
-            </dependency>
-
             <!-- Netty bom -->
             <dependency>
                 <groupId>io.netty</groupId>


### PR DESCRIPTION
Remove the threetenbp override; no longer needed on camel-google-bigquery