### PR TITLE
Add camel-jq, camel-elasticsearch-rest-client, camel-hashicorp-vault, camel-graphql to list of productized starters

### DIFF
--- a/.mvn/excludes.txt
+++ b/.mvn/excludes.txt
@@ -40,6 +40,7 @@
 :camel-cbor-starter
 :camel-chatscript-starter
 :camel-chunk-starter
+:camel-cics-starter
 :camel-cloudevents-starter
 :camel-cm-sms-starter
 :camel-coap-starter
@@ -71,7 +72,6 @@
 :camel-dsl-modeline-starter
 :camel-dynamic-router-starter
 :camel-ehcache-starter
-:camel-elasticsearch-rest-client-starter
 :camel-etcd3-starter
 :camel-exec-starter
 :camel-fastjson-starter
@@ -92,11 +92,9 @@
 :camel-google-sheets-starter
 :camel-google-storage-starter
 :camel-grape-starter
-:camel-graphql-starter
 :camel-grok-starter
 :camel-groovy-dsl-starter
 :camel-guava-eventbus-starter
-:camel-hashicorp-vault-starter
 :camel-hazelcast-starter
 :camel-huaweicloud-dms-starter
 :camel-huaweicloud-frs-starter
@@ -117,6 +115,7 @@
 :camel-javascript-starter
 :camel-jcache-starter
 :camel-jcr-starter
+:camel-jetty-starter
 :camel-jfr-starter
 :camel-jgroups-cluster-service-starter
 :camel-jgroups-raft-cluster-service-starter
@@ -126,7 +125,6 @@
 :camel-jolt-starter
 :camel-jooq-starter
 :camel-joor-starter
-:camel-jq-starter
 :camel-js-dsl-starter
 :camel-jsch-starter
 :camel-jsh-dsl-starter
@@ -151,7 +149,6 @@
 :camel-lucene-starter
 :camel-lumberjack-starter
 :camel-lzf-starter
-:camel-management-starter
 :camel-metrics-starter
 :camel-milvus-starter
 :camel-mina-starter
@@ -234,5 +231,10 @@
 :camel-zookeeper-cluster-service-starter
 :camel-zookeeper-master-starter
 :camel-zookeeper-starter
+:dependency-management-example
+:dependency-management-example-module1
 :docs
+:redhat-camel-spring-boot-maintenance
+:redhat-camel-spring-boot-patch-metadata
+:redhat-camel-spring-boot-patch-repository
 :tests

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/constant.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/constant.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.8.0-SNAPSHOT",
+    "version": "4.8.0.redhat-00002",
     "modelName": "constant",
     "modelJavaType": "org.apache.camel.model.language.ConstantExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/csimple.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/csimple.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.8.0-SNAPSHOT",
+    "version": "4.8.0.redhat-00002",
     "modelName": "csimple",
     "modelJavaType": "org.apache.camel.model.language.CSimpleExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/exchangeProperty.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/exchangeProperty.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.8.0-SNAPSHOT",
+    "version": "4.8.0.redhat-00002",
     "modelName": "exchangeProperty",
     "modelJavaType": "org.apache.camel.model.language.ExchangePropertyExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/file.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/file.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.8.0-SNAPSHOT",
+    "version": "4.8.0.redhat-00002",
     "modelName": "simple",
     "modelJavaType": "org.apache.camel.model.language.SimpleExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/header.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/header.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.8.0-SNAPSHOT",
+    "version": "4.8.0.redhat-00002",
     "modelName": "header",
     "modelJavaType": "org.apache.camel.model.language.HeaderExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/ref.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/ref.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.8.0-SNAPSHOT",
+    "version": "4.8.0.redhat-00002",
     "modelName": "ref",
     "modelJavaType": "org.apache.camel.model.language.RefExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/simple.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/simple.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.8.0-SNAPSHOT",
+    "version": "4.8.0.redhat-00002",
     "modelName": "simple",
     "modelJavaType": "org.apache.camel.model.language.SimpleExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/tokenize.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/tokenize.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.8.0-SNAPSHOT",
+    "version": "4.8.0.redhat-00002",
     "modelName": "tokenize",
     "modelJavaType": "org.apache.camel.model.language.TokenizerExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/variable.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/variable.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.8.0-SNAPSHOT",
+    "version": "4.8.0.redhat-00002",
     "modelName": "variable",
     "modelJavaType": "org.apache.camel.model.language.VariableExpression"
   },

--- a/cics/pom.xml
+++ b/cics/pom.xml
@@ -35,6 +35,6 @@
   </build>
 
   <modules>
-    <module>camel-cics-starter</module>
+    <!-- <module>camel-cics-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
   </modules>
 </project>

--- a/components-starter/pom.xml
+++ b/components-starter/pom.xml
@@ -205,7 +205,7 @@
     <!-- <module>camel-dropbox-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-dynamic-router-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-ehcache-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
-    <!-- <module>camel-elasticsearch-rest-client-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
+    <module>camel-elasticsearch-rest-client-starter</module>
     <module>camel-elasticsearch-starter</module>
     <!-- <module>camel-etcd3-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-exec-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
@@ -233,13 +233,13 @@
     <!-- <module>camel-google-sheets-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-google-storage-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-grape-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
-    <!-- <module>camel-graphql-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
+    <module>camel-graphql-starter</module>
     <!-- <module>camel-grok-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <module>camel-groovy-starter</module>
     <module>camel-grpc-starter</module>
     <module>camel-gson-starter</module>
     <!-- <module>camel-guava-eventbus-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
-    <!-- <module>camel-hashicorp-vault-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
+    <module>camel-hashicorp-vault-starter</module>
     <!-- <module>camel-hazelcast-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <module>camel-hl7-starter</module>
     <module>camel-http-starter</module>
@@ -284,7 +284,7 @@
     <!-- <module>camel-jooq-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-joor-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <module>camel-jpa-starter</module>
-    <!-- <module>camel-jq-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
+    <module>camel-jq-starter</module>
     <!-- <module>camel-jsch-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <module>camel-jslt-starter</module>
     <!-- <module>camel-json-patch-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
@@ -316,7 +316,7 @@
     <!-- <module>camel-lzf-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <module>camel-mail-microsoft-oauth-starter</module>
     <module>camel-mail-starter</module>
-    <!-- <module>camel-management-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
+    <module>camel-management-starter</module>
     <module>camel-mapstruct-starter</module>
     <module>camel-master-starter</module>
     <!-- <module>camel-metrics-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dependencies</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
     </parent>
 
     <groupId>org.apache.camel.springboot</groupId>
@@ -113,7 +113,7 @@
         <spring-boot-version>3.3.3</spring-boot-version>
 
         <!-- Camel target version -->
-        <camel-version>4.8.0.redhat-00002</camel-version>
+        <camel-version>4.8.0.redhat-00003</camel-version>
 
         <!-- cq plugin version -->
         <cq-plugin.version>4.4.11</cq-plugin.version>

--- a/product/src/main/resources/required-productized-camel-artifacts.txt
+++ b/product/src/main/resources/required-productized-camel-artifacts.txt
@@ -44,6 +44,7 @@ camel-dataformat-starter
 camel-dataset-starter
 camel-direct-starter
 camel-elasticsearch-starter
+camel-elasticsearch-rest-client-starter
 camel-endpointdsl-starter
 camel-fhir-starter
 camel-file-starter
@@ -51,9 +52,11 @@ camel-flink-starter
 camel-ftp-starter
 camel-google-bigquery-starter
 camel-google-pubsub-starter
+camel-graphql-starter
 camel-groovy-starter
 camel-grpc-starter
 camel-gson-starter
+camel-hashicorp-vault-starter
 camel-hl7-starter
 camel-http-starter
 camel-infinispan-starter
@@ -70,6 +73,7 @@ camel-jira-starter
 camel-jms-starter
 camel-jolokia-starter
 camel-jpa-starter
+camel-jq-starter
 camel-jslt-starter
 camel-jsonpath-starter
 camel-kafka-starter

--- a/tooling/camel-spring-boot-bom/pom.xml
+++ b/tooling/camel-spring-boot-bom/pom.xml
@@ -571,7 +571,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-elasticsearch-rest-client-starter</artifactId>
-        <version>4.8.0</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -716,7 +716,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-graphql-starter</artifactId>
-        <version>4.8.0</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -751,7 +751,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-hashicorp-vault-starter</artifactId>
-        <version>4.8.0</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -981,7 +981,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-jq-starter</artifactId>
-        <version>4.8.0</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -290,17 +290,17 @@
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-debezium-maven-plugin</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-salesforce-maven-plugin</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-servicenow-maven-plugin</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -825,7 +825,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-elasticsearch-rest-client-starter</artifactId>
-        <version>4.8.0</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -970,7 +970,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-graphql-starter</artifactId>
-        <version>4.8.0</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -1005,7 +1005,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-hashicorp-vault-starter</artifactId>
-        <version>4.8.0</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -1235,7 +1235,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-jq-starter</artifactId>
-        <version>4.8.0</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -2145,7 +2145,7 @@
       <dependency>
         <groupId>org.apache.camel.tests</groupId>
         <artifactId>org.apache.camel.tests.mock-javamail_1.7</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2160,18 +2160,18 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-allcomponents</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-amqp</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-api</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2211,12 +2211,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-attachments</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-avro</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2266,12 +2266,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-cw</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ddb</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2301,7 +2301,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-kinesis</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2311,7 +2311,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-lambda</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2331,7 +2331,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-s3</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2341,12 +2341,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sns</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sqs</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2376,7 +2376,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-eventhubs</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2396,12 +2396,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-servicebus</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-blob</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2411,7 +2411,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-queue</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2421,12 +2421,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base-engine</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2436,22 +2436,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean-validator</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-beanio</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bindy</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2476,7 +2476,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-browse</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2486,22 +2486,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cassandraql</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog-console</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog-lucene</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2526,22 +2526,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cli-connector</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloud</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloudevents</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cluster</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2561,12 +2561,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-componentdsl</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-console</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2576,12 +2576,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-controlbus</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2592,37 +2592,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-catalog</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-engine</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-languages</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-model</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-processor</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-reifier</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-xml</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2637,12 +2637,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cron</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-crypto</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2667,52 +2667,52 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-common</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-rest</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-soap</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-common</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-rest</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-soap</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-transport</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-transport</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataformat</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataset</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2777,7 +2777,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-direct</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2812,12 +2812,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-modeline</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-support</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2832,12 +2832,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch-rest-client</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2847,12 +2847,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl-support</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2872,17 +2872,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir-api</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-file</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2897,7 +2897,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-flink</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2912,7 +2912,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ftp</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2932,7 +2932,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-bigquery</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2957,7 +2957,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-pubsub</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2987,7 +2987,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-graphql</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2997,7 +2997,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-groovy</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3012,12 +3012,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-grpc</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-gson</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3027,7 +3027,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hashicorp-vault</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3042,27 +3042,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-health</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hl7</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-base</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-common</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3122,17 +3122,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-common</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-embedded</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3157,32 +3157,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-avro</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-protobuf</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jacksonxml</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jasypt</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-java-joor-dsl</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3192,7 +3192,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jaxb</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3237,7 +3237,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jdbc</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3252,7 +3252,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jfr</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3267,12 +3267,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jira</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jms</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3292,17 +3292,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-joor</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jpa</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jq</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3322,7 +3322,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jslt</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3352,17 +3352,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonpath</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jt400</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jta</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3372,32 +3372,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kafka</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet-main</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-api</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-http</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3412,12 +3412,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kubernetes</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kudu</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3452,12 +3452,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-language</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ldap</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3472,12 +3472,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-log</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lra</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3497,37 +3497,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail-microsoft-oauth</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-main</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management-api</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mapstruct</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-master</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3537,7 +3537,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-micrometer</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3547,17 +3547,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-config</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-fault-tolerance</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-health</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3572,22 +3572,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-minio</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mllp</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mock</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mongodb</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3607,22 +3607,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mybatis</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nats</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty-http</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3657,22 +3657,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4-api</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-java</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-rest-dsl-generator</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3682,7 +3682,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opensearch</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3692,7 +3692,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opentelemetry</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3702,12 +3702,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho-mqtt5</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3737,7 +3737,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3747,12 +3747,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-main</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-vertx</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3792,7 +3792,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-quartz</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3827,7 +3827,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ref</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3837,7 +3837,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-resilience4j</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3847,12 +3847,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest-openapi</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3882,12 +3882,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saga</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-salesforce</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3902,12 +3902,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saxon</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-scheduler</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3917,7 +3917,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-seda</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3932,7 +3932,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-servlet</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3952,12 +3952,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-slack</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smb</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3977,12 +3977,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-snmp</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-soap</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3992,67 +3992,67 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk-hec</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-batch</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-jdbc</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-ldap</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-main</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-rabbitmq</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-redis</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-security</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-ws</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-xml</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sql</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4087,12 +4087,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stub</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-support</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4117,17 +4117,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-telegram</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-junit5</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4137,7 +4137,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-spring-junit5</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4162,27 +4162,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-timer</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-maven</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-model</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-util</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tracing</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4197,12 +4197,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-undertow</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-undertow-spring-security</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4212,22 +4212,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util-json</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-validator</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-velocity</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4237,17 +4237,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-common</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-http</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-websocket</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4272,7 +4272,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-webhook</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4297,27 +4297,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xj</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-dsl</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-util</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxb</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4327,12 +4327,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp-util</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4347,37 +4347,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xpath</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt-saxon</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-common</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-deserializers</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-io</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4392,12 +4392,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zip-deflater</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zipfile</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4417,7 +4417,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>spi-annotations</artifactId>
-        <version>4.8.0.redhat-00002</version>
+        <version>4.8.0.redhat-00003</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -92,11 +92,6 @@
                 <artifactId>undertow-servlet</artifactId>
                 <version>2.3.17.Final</version>
             </dependency>
-            <dependency>
-                <groupId>io.undertow</groupId>
-                <artifactId>undertow-websockets-jsr</artifactId>
-                <version>2.3.17.Final</version>
-            </dependency>
             <!-- Overrides guava -->
             <dependency>
                 <groupId>com.google.guava</groupId>
@@ -536,12 +531,12 @@
             <dependency>
                 <groupId>org.jboss.xnio</groupId>
                 <artifactId>xnio-api</artifactId>
-                <version>3.3.8.Final</version>
+                <version>3.8.14.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.xnio</groupId>
                 <artifactId>xnio-nio</artifactId>
-                <version>3.3.8.Final</version>
+                <version>3.8.14.Final</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Add camel-jq, camel-elasticsearch-rest-client, camel-hashicorp-vault, camel-graphql to list of productized starters
Update camel version for supported camel components for the starters listed above
Refresh