### PR TITLE
Ensure that cics-starter is productized

### DIFF
--- a/.mvn/excludes.txt
+++ b/.mvn/excludes.txt
@@ -40,7 +40,6 @@
 :camel-cbor-starter
 :camel-chatscript-starter
 :camel-chunk-starter
-:camel-cics-starter
 :camel-cloudevents-starter
 :camel-cm-sms-starter
 :camel-coap-starter

--- a/cics/pom.xml
+++ b/cics/pom.xml
@@ -35,6 +35,6 @@
   </build>
 
   <modules>
-    <!-- <module>camel-cics-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
+    <module>camel-cics-starter</module>
   </modules>
 </project>

--- a/product/src/main/resources/required-productized-camel-artifacts.txt
+++ b/product/src/main/resources/required-productized-camel-artifacts.txt
@@ -1,6 +1,7 @@
 org.apache.camel.archetypes:camel-archetype-spring-boot
 org.apache.camel.springboot:catalog
 org.apache.camel.springboot:camel-catalog-provider-springboot
+org.fusesource:camel-cics-starter
 com.redhat.camel.springboot.platform:patch-maven-plugin
 com.redhat.camel.springboot.platform:redhat-camel-spring-boot-bom
 com.redhat.camel.springboot.platform:redhat-camel-spring-boot-bom-generator


### PR DESCRIPTION
The cics-starter is being marked as community in error by the prod-maven-plugin and the issue seems to be the non-standard groupId (org.fusesource) of the camel-cics-starter.     Added org.fusesource:camel-cics-starter as an additional entry and that seems to fix the issue.