### PR TITLE
Update camel to 4.8.0.redhat-00004

### DIFF
--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/constant.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/constant.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.8.0.redhat-00002",
+    "version": "4.8.0-SNAPSHOT",
     "modelName": "constant",
     "modelJavaType": "org.apache.camel.model.language.ConstantExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/csimple.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/csimple.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.8.0.redhat-00002",
+    "version": "4.8.0-SNAPSHOT",
     "modelName": "csimple",
     "modelJavaType": "org.apache.camel.model.language.CSimpleExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/exchangeProperty.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/exchangeProperty.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.8.0.redhat-00002",
+    "version": "4.8.0-SNAPSHOT",
     "modelName": "exchangeProperty",
     "modelJavaType": "org.apache.camel.model.language.ExchangePropertyExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/file.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/file.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.8.0.redhat-00002",
+    "version": "4.8.0-SNAPSHOT",
     "modelName": "simple",
     "modelJavaType": "org.apache.camel.model.language.SimpleExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/header.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/header.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.8.0.redhat-00002",
+    "version": "4.8.0-SNAPSHOT",
     "modelName": "header",
     "modelJavaType": "org.apache.camel.model.language.HeaderExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/ref.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/ref.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.8.0.redhat-00002",
+    "version": "4.8.0-SNAPSHOT",
     "modelName": "ref",
     "modelJavaType": "org.apache.camel.model.language.RefExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/simple.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/simple.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.8.0.redhat-00002",
+    "version": "4.8.0-SNAPSHOT",
     "modelName": "simple",
     "modelJavaType": "org.apache.camel.model.language.SimpleExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/tokenize.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/tokenize.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.8.0.redhat-00002",
+    "version": "4.8.0-SNAPSHOT",
     "modelName": "tokenize",
     "modelJavaType": "org.apache.camel.model.language.TokenizerExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/variable.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/variable.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.8.0.redhat-00002",
+    "version": "4.8.0-SNAPSHOT",
     "modelName": "variable",
     "modelJavaType": "org.apache.camel.model.language.VariableExpression"
   },

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dependencies</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
     </parent>
 
     <groupId>org.apache.camel.springboot</groupId>
@@ -113,7 +113,7 @@
         <spring-boot-version>3.3.3</spring-boot-version>
 
         <!-- Camel target version -->
-        <camel-version>4.8.0.redhat-00003</camel-version>
+        <camel-version>4.8.0.redhat-00004</camel-version>
 
         <!-- cq plugin version -->
         <cq-plugin.version>4.4.11</cq-plugin.version>

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -290,17 +290,17 @@
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-debezium-maven-plugin</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-salesforce-maven-plugin</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-servicenow-maven-plugin</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -2145,7 +2145,7 @@
       <dependency>
         <groupId>org.apache.camel.tests</groupId>
         <artifactId>org.apache.camel.tests.mock-javamail_1.7</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2160,18 +2160,18 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-allcomponents</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-amqp</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-api</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2211,12 +2211,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-attachments</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-avro</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2251,7 +2251,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-secrets-manager</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2266,12 +2266,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-cw</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ddb</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2301,7 +2301,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-kinesis</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2311,7 +2311,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-lambda</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2331,7 +2331,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-s3</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2341,12 +2341,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sns</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sqs</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2376,7 +2376,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-eventhubs</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2386,7 +2386,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-key-vault</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2396,12 +2396,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-servicebus</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-blob</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2411,7 +2411,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-queue</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2421,12 +2421,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base-engine</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2436,22 +2436,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean-validator</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-beanio</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bindy</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2476,7 +2476,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-browse</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2486,22 +2486,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cassandraql</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog-console</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog-lucene</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2526,22 +2526,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cli-connector</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloud</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloudevents</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cluster</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2561,12 +2561,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-componentdsl</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-console</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2576,12 +2576,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-controlbus</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2592,37 +2592,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-catalog</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-engine</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-languages</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-model</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-processor</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-reifier</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-xml</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2637,12 +2637,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cron</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-crypto</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2667,52 +2667,52 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-common</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-rest</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-soap</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-common</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-rest</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-soap</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-transport</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-transport</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataformat</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataset</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2777,7 +2777,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-direct</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2812,12 +2812,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-modeline</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-support</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2832,12 +2832,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch-rest-client</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2847,12 +2847,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl-support</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2872,17 +2872,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir-api</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-file</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2897,7 +2897,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-flink</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2912,7 +2912,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ftp</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2932,7 +2932,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-bigquery</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2957,7 +2957,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-pubsub</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2967,7 +2967,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-secret-manager</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2987,7 +2987,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-graphql</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2997,7 +2997,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-groovy</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3012,12 +3012,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-grpc</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-gson</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3027,7 +3027,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hashicorp-vault</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3042,27 +3042,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-health</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hl7</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-base</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-common</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3122,17 +3122,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-common</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-embedded</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3157,32 +3157,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-avro</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-protobuf</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jacksonxml</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jasypt</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-java-joor-dsl</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3192,7 +3192,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jaxb</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3237,7 +3237,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jdbc</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3252,7 +3252,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jfr</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3267,12 +3267,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jira</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jms</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3292,17 +3292,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-joor</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jpa</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jq</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3322,7 +3322,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jslt</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3352,17 +3352,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonpath</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jt400</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jta</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3372,32 +3372,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kafka</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet-main</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-api</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-http</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3412,12 +3412,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kubernetes</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kudu</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3452,12 +3452,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-language</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ldap</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3472,12 +3472,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-log</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lra</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3497,37 +3497,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail-microsoft-oauth</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-main</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management-api</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mapstruct</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-master</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3537,7 +3537,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-micrometer</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3547,17 +3547,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-config</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-fault-tolerance</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-health</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3572,22 +3572,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-minio</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mllp</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mock</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mongodb</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3607,22 +3607,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mybatis</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nats</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty-http</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3657,22 +3657,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4-api</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-java</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-rest-dsl-generator</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3682,7 +3682,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opensearch</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3692,7 +3692,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opentelemetry</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3702,12 +3702,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho-mqtt5</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3737,7 +3737,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3747,12 +3747,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-main</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-vertx</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3792,7 +3792,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-quartz</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3827,7 +3827,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ref</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3837,7 +3837,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-resilience4j</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3847,12 +3847,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest-openapi</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3882,12 +3882,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saga</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-salesforce</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3902,12 +3902,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saxon</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-scheduler</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3917,7 +3917,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-seda</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3932,7 +3932,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-servlet</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3952,12 +3952,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-slack</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smb</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3977,12 +3977,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-snmp</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-soap</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3992,67 +3992,67 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk-hec</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-batch</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-jdbc</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-ldap</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-main</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-rabbitmq</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-redis</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-security</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-ws</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-xml</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sql</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4087,12 +4087,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stub</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-support</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4117,17 +4117,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-telegram</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-junit5</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4137,7 +4137,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-spring-junit5</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4162,27 +4162,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-timer</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-maven</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-model</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-util</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tracing</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4197,12 +4197,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-undertow</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-undertow-spring-security</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4212,22 +4212,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util-json</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-validator</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-velocity</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4237,17 +4237,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-common</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-http</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-websocket</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4272,7 +4272,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-webhook</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4297,27 +4297,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xj</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-dsl</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-util</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxb</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4327,12 +4327,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp-util</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4347,37 +4347,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xpath</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt-saxon</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-common</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-deserializers</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-io</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4392,12 +4392,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zip-deflater</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zipfile</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4417,7 +4417,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>spi-annotations</artifactId>
-        <version>4.8.0.redhat-00003</version>
+        <version>4.8.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -465,7 +465,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
-                <version>1.12.0</version>
+                <version>1.12.0.redhat-00001</version>
             </dependency>
 
             <dependency>
@@ -542,17 +542,17 @@
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
-                <version>9.7</version>
+                <version>9.7.0.redhat-00001</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-commons</artifactId>
-                <version>9.7</version>
+                <version>9.7.0.redhat-00001</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-tree</artifactId>
-                <version>9.7</version>
+                <version>9.7.0.redhat-00001</version>
             </dependency>
 
             <dependency>
@@ -604,7 +604,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-bom</artifactId>
-                <version>4.0.5.redhat-00001</version>
+                <version>4.0.5.fuse-redhat-00006</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Update camel version to 4.8.0.redhat-00004

This is significant because we are getting failures in the PR tests around cxf (see https://ci-jenkins-csb-fuse.apps.ocp-c1.prod.psi.redhat.com/blue/organizations/jenkins/CamelSpringBoot%2Fcamel-spring-boot/detail/PR-441/4/pipeline);  Freeman says that the fix is in cxf commit e489d6c2a1407340ed9bfe4f4b0d8da055cd0477 which is in the cxf version used by camel 4.8.0.redhat-00004