### PR TITLE
[cics] Removed org.fusesource:camel-cics-starter

### DIFF
--- a/product/src/main/resources/required-productized-camel-artifacts.txt
+++ b/product/src/main/resources/required-productized-camel-artifacts.txt
@@ -1,7 +1,6 @@
 org.apache.camel.archetypes:camel-archetype-spring-boot
 org.apache.camel.springboot:catalog
 org.apache.camel.springboot:camel-catalog-provider-springboot
-org.fusesource:camel-cics-starter
 com.redhat.camel.springboot.platform:patch-maven-plugin
 com.redhat.camel.springboot.platform:redhat-camel-spring-boot-bom
 com.redhat.camel.springboot.platform:redhat-camel-spring-boot-bom-generator


### PR DESCRIPTION
since there is `camel-cics-starter-parent` and `camel-cics-starter` I don't know if also `org.fusesource:camel-cics-starter` is necessary, am I wrong @cunningt ?