### PR TITLE
Manages undertow-websockets-jsr

### DIFF
--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -92,6 +92,11 @@
                 <artifactId>undertow-servlet</artifactId>
                 <version>${undertow-version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.undertow</groupId>
+                <artifactId>undertow-websockets-jsr</artifactId>
+                <version>${undertow-version}</version>
+            </dependency>
             <!-- Overrides guava -->
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -92,6 +92,11 @@
                 <artifactId>undertow-servlet</artifactId>
                 <version>2.3.17.Final</version>
             </dependency>
+            <dependency>
+                <groupId>io.undertow</groupId>
+                <artifactId>undertow-websockets-jsr</artifactId>
+                <version>2.3.17.Final</version>
+            </dependency>
             <!-- Overrides guava -->
             <dependency>
                 <groupId>com.google.guava</groupId>
@@ -179,7 +184,7 @@
             <dependency>
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro</artifactId>
-                <version>1.11.0</version>
+                <version>1.12.0</version>
             </dependency>
             <!-- Override commons-compress version -->
             <dependency>


### PR DESCRIPTION
In https://github.com/jboss-fuse/camel-spring-boot/commit/6611be4d1235d1c38a985403848d4de265220327 a dependencyManagement entry for undertow-websockets-jsr was added but it was added to the bom directly and not to the bom generator template - it looks like it got overwritten the next time someone built.

Added it to the bom and then did a refresh and an avro change popped up in the refresh of the BOM, looks related to https://github.com/jboss-fuse/camel-spring-boot/commit/192019044fad3396a5c5458b37f42e597197b540