### PR TITLE
Use camel-jetty component rather than camel-jetty-starter

### DIFF
--- a/core/camel-spring-boot-xml/pom.xml
+++ b/core/camel-spring-boot-xml/pom.xml
@@ -93,8 +93,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-jetty-starter</artifactId>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-jetty</artifactId>
             <version>${camel-community.version}</version>
             <scope>test</scope>
         </dependency>
@@ -118,15 +118,6 @@
                 </executions>
             </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>**/*MixedRestDslTest.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Build failure : https://ci-jenkins-csb-fuse.apps.ocp-c1.prod.psi.redhat.com/blue/rest/organizations/jenkins/pipelines/CamelSpringBoot/pipelines/camel-spring-boot/branches/PR-457/runs/1/nodes/34/steps/43/log/?start=0

A camel-jetty-starter dependency within camel-spring-boot-xml creates a circular dependency; core is needed to build camel-jetty-starter but when trying to build camel-spring-boot-xml the camel-jetty-starter artifact will never be built and ready.     Maven may allow this via bootstrapping w/snapshot builds but the build will fail when we try to build cleanly (like in the PR tests).

I think a good solution would be to substitute the use of the camel-jetty component for the camel-jetty-starter starter.    