### PR TITLE
[CSB-5877] JBang export from spring-boot template fix

### DIFF
--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/catalog/camel-jbang/spring-boot-pom.tmpl
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/catalog/camel-jbang/spring-boot-pom.tmpl
@@ -19,7 +19,7 @@
 		<surefire.plugin.version>3.5.0</surefire.plugin.version>
 		<jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
 		<camel.spring.boot-version>{{ .CamelSpringBootVersion }}</camel.spring.boot-version>
-{{ .AdditionalProperties }}
+{{ .BuildProperties }}
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
_--additional-properties_ config option is no more supported:

i.e. Output of `camel export -h` :

`Export to other runtimes (Camel Main, Spring Boot, or Quarkus)
      [<files>...]           The Camel file(s) to export. If no files is
                               specified then what was last run will be
                               exported.
     --build-property=<buildProperties>
                             Maven/Gradle build properties, ex.
                               --build-property=prop1=foo`
