### PR TITLE
Add a dependencyManagement entry for camel-kamelet-bom so we align to the correct productized version of camel-kamelets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,17 @@
 
     <dependencyManagement>
         <dependencies>
+
+
+
+            <!-- org.apache.camel.kamelets:camel-kamelets-bom dependencyManagement entry
+                is necessary for PME align to the correct camel-kamelets-version -->
+            <dependency>
+                <groupId>org.apache.camel.kamelets</groupId>
+                <artifactId>camel-kamelets-bom</artifactId>
+                <version>${camel-kamelets-version}</version>
+            </dependency>
+
             <!-- dev.snowdrop:narayana-spring-boot-core dependencyManagement entry
                 is necessary for PME align to the correct narayana-spring-boot.version -->
             <dependency>

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -288,6 +288,11 @@
         <version>1.12.0</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.camel.kamelets</groupId>
+        <artifactId>camel-kamelets-bom</artifactId>
+        <version>4.8.0</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-debezium-maven-plugin</artifactId>
         <version>4.8.0.redhat-00005</version>


### PR DESCRIPTION
In the CS3 handover, the camel-kamelets version in the camel-spring-boot root pom.xml did not align.      It needs a dependency management entry in order that PME aligns it to the correct version.

Add a dependencyManagement entry for camel-kamelet-bom so we align to the correct productized version of camel-kamelets