### PR TITLE
Change usage of STRICT_VALIDATOR to UTF_VALIDATOR

### DIFF
--- a/components-starter/camel-jackson-avro-starter/src/test/java/org/apache/camel/component/jackson/avro/springboot/test/JacksonAvroLookupResolverTest.java
+++ b/components-starter/camel-jackson-avro-starter/src/test/java/org/apache/camel/component/jackson/avro/springboot/test/JacksonAvroLookupResolverTest.java
@@ -58,7 +58,7 @@ public class JacksonAvroLookupResolverTest {
     private SchemaResolver getSchemaResolver() {
         String schemaJson = "{\n" + "\"type\": \"record\",\n" + "\"name\": \"Pojo\",\n" + "\"fields\": [\n"
                 + " {\"name\": \"text\", \"type\": \"string\"}\n" + "]}";
-        Schema raw = new Schema.Parser(NameValidator.STRICT_VALIDATOR).parse(schemaJson);
+        Schema raw = new Schema.Parser(NameValidator.UTF_VALIDATOR).parse(schemaJson);
         AvroSchema schema = new AvroSchema(raw);
         SchemaResolver resolver = ex -> schema;
 

--- a/components-starter/camel-jackson-avro-starter/src/test/java/org/apache/camel/component/jackson/avro/springboot/test/JacksonAvroMarshalUnmarshalJsonNodeTest.java
+++ b/components-starter/camel-jackson-avro-starter/src/test/java/org/apache/camel/component/jackson/avro/springboot/test/JacksonAvroMarshalUnmarshalJsonNodeTest.java
@@ -71,10 +71,10 @@ public class JacksonAvroMarshalUnmarshalJsonNodeTest {
                 + "    \"type\":\"record\",\n" + "    \"fields\":[\n"
                 + "      {\"name\":\"text\", \"type\":\"string\"}\n" + "    ]\n" + "  }\n" + "}";
 
-        Schema raw = new Schema.Parser(NameValidator.STRICT_VALIDATOR).parse(schemaJson);
+        Schema raw = new Schema.Parser(NameValidator.UTF_VALIDATOR).parse(schemaJson);
         AvroSchema schema = new AvroSchema(raw);
 
-        Schema rawList = new Schema.Parser(NameValidator.STRICT_VALIDATOR).parse(listSchemaJson);
+        Schema rawList = new Schema.Parser(NameValidator.UTF_VALIDATOR).parse(listSchemaJson);
         AvroSchema schemaList = new AvroSchema(rawList);
 
         SchemaResolver resolver = ex -> {

--- a/components-starter/camel-jackson-avro-starter/src/test/java/org/apache/camel/component/jackson/avro/springboot/test/JacksonAvroMarshalUnmarshalPojoListTest.java
+++ b/components-starter/camel-jackson-avro-starter/src/test/java/org/apache/camel/component/jackson/avro/springboot/test/JacksonAvroMarshalUnmarshalPojoListTest.java
@@ -63,7 +63,7 @@ public class JacksonAvroMarshalUnmarshalPojoListTest {
         String schemaJson = "{\n" + "  \"type\": \"array\",  \n" + "  \"items\":{\n" + "    \"name\":\"Pojo\",\n"
                 + "    \"type\":\"record\",\n" + "    \"fields\":[\n"
                 + "      {\"name\":\"text\", \"type\":\"string\"}\n" + "    ]\n" + "  }\n" + "}";
-        Schema raw = new Schema.Parser(NameValidator.STRICT_VALIDATOR).parse(schemaJson);
+        Schema raw = new Schema.Parser(NameValidator.UTF_VALIDATOR).parse(schemaJson);
         AvroSchema schema = new AvroSchema(raw);
         SchemaResolver resolver = ex -> schema;
 

--- a/components-starter/camel-jackson-avro-starter/src/test/java/org/apache/camel/component/jackson/avro/springboot/test/JacksonAvroMarshalUnmarshalPojoTest.java
+++ b/components-starter/camel-jackson-avro-starter/src/test/java/org/apache/camel/component/jackson/avro/springboot/test/JacksonAvroMarshalUnmarshalPojoTest.java
@@ -58,7 +58,7 @@ public class JacksonAvroMarshalUnmarshalPojoTest {
     private SchemaResolver getSchemaResolver() {
         String schemaJson = "{\n" + "\"type\": \"record\",\n" + "\"name\": \"Pojo\",\n" + "\"fields\": [\n"
                 + " {\"name\": \"text\", \"type\": \"string\"}\n" + "]}";
-        Schema raw = new Schema.Parser(NameValidator.STRICT_VALIDATOR).parse(schemaJson);
+        Schema raw = new Schema.Parser(NameValidator.UTF_VALIDATOR).parse(schemaJson);
         AvroSchema schema = new AvroSchema(raw);
         SchemaResolver resolver = ex -> schema;
 


### PR DESCRIPTION
Change usage of STRICT_VALIDATOR to UTF_VALIDATOR; @jamesnetherton pointed out that UTF_VALIDATOR is the default and STRICT_VALIDATOR has additional requirements.     Seems like the replacement to setValidate(true) is better matched to UTF_VALIDATOR

https://github.com/apache/avro/blob/release-1.12.0/lang/java/avro/src/main/java/org/apache/avro/Schema.java#L1433-L1435

Compiled, ran tests on camel-jackson-avro, made this change upstream as well https://github.com/apache/camel-spring-boot/pull/1273
