### PR TITLE
CSB-5913 Add overrides for camel-support and camel-api so that we use the productized versions in all instances (both for supported and for unsupported components)

### DIFF
--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -69,6 +69,19 @@
     <dependencyManagement>
         <dependencies>
 
+            <!-- CSB-5913 - please remove these overrides after 4.8.0 -->
+            <!-- These are required for the ThreadFactoryListener changes -->
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-api</artifactId>
+                <version>${camel-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-support</artifactId>
+                <version>${camel-version}</version>
+            </dependency>
+
             <!-- Insert third party overrides here -->
             <dependency>
                 <groupId>org.yaml</groupId>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -69,6 +69,18 @@
     <dependencyManagement>
         <dependencies>
 
+            <!-- CSB-5913 - please remove these overrides after 4.8.0 -->
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-api</artifactId>
+                <version>4.8.0.redhat-00010</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-support</artifactId>
+                <version>4.8.0.redhat-00010</version>
+            </dependency>
+
             <!-- Insert third party overrides here -->
             <dependency>
                 <groupId>org.yaml</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/CSB-5913 describes an issue where the use of an unsupported component (camel-stream in this instance) confuses the classpath of supported components which require the use of the supported versions of camel-support/camel-api because of the addition of org/apache/camel/spi/ExecutorServiceManager$ThreadFactoryListener.    

We've tried to remove the org/apache/camel/spi/ExecutorServiceManager$ThreadFactoryListener changes but it appears as if they are needed for CAMEL-21202 and CAMEL-21202 is necessary for 4.8.0.    Proposal here is :

- add overrides for camel-api / camel-support so that the productized camel-api/camel-support is used for both productized and unsupported components
- add back https://github.com/jboss-fuse/camel/commit/31af6d1c23072ad1c33c9fe2e6f366da2da4a576
- add back https://github.com/jboss-fuse/camel/commit/2c817c37eee86333337cff9054b2714eb7acedc6


