### PR TITLE
Use a separate version for jolokia so we can use productized build of jolokia

### DIFF
--- a/components-starter/camel-jolokia-starter/pom.xml
+++ b/components-starter/camel-jolokia-starter/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>org.jolokia</groupId>
       <artifactId>jolokia-support-spring</artifactId>
-      <version>${jolokia-version}</version>
+      <version>${jolokia-starter-jolokia-version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel.springboot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,7 @@
         <graal-sdk-version>22.3.2</graal-sdk-version>
         <jakarta-jaxb-version>4.0.0</jakarta-jaxb-version>
         <jaxb-version>2.3.0</jaxb-version>
+        <jolokia-starter-jolokia-version>2.1.2</jolokia-starter-jolokia-version>
         <maven-compiler-plugin-version>3.11.0</maven-compiler-plugin-version>
         <maven.compiler.release>${jdk.version}</maven.compiler.release>
         <maven-javadoc-plugin-version>3.10.0</maven-javadoc-plugin-version>


### PR DESCRIPTION
jolokia-version from camel-parent is unused in the productized camel build because camel-platform-http-jolokia is unsupported.    camel-platform-http-jolokia is the only place where that version is used in a dependency or dependencymanagement entry so it's basically and orphaned version within camel.

In order to align to productized jolokia within camel-spring-boot, we should add a separate jolokia version within c-s-b - the dependency in camel-jolokia-starter will ensure that it gets aligned.