### PR TITLE
CSB-6387 Close streams noted as resource leaks from OpenScanHub results

### DIFF
--- a/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/RequiredProductizedArtifactsReader.java
+++ b/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/RequiredProductizedArtifactsReader.java
@@ -34,9 +34,8 @@ import java.util.HashMap;
     public static HashMap<String, Boolean> getProductizedCSBArtifacts(File requiredFile) {
         HashMap<String, Boolean> map = new HashMap<>();
 
-        try {
-            FileReader fileReader = new FileReader(requiredFile);
-            BufferedReader br = new BufferedReader(fileReader);
+        try (FileReader fileReader = new FileReader(requiredFile);
+            BufferedReader br = new BufferedReader(fileReader)) {
 
             String line;
             while ((line = br.readLine()) != null) {
@@ -50,8 +49,6 @@ import java.util.HashMap;
                     map.replace(line, true);
                 }
             }
-            br.close();
-            fileReader.close();
         } catch (IOException ioe) {
             throw new RuntimeException(ioe);
         }

--- a/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/RequiredProductizedArtifactsReader.java
+++ b/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/RequiredProductizedArtifactsReader.java
@@ -50,6 +50,8 @@ import java.util.HashMap;
                     map.replace(line, true);
                 }
             }
+            br.close();
+            fileReader.close();
         } catch (IOException ioe) {
             throw new RuntimeException(ioe);
         }

--- a/tooling/redhat-patch-maven-plugin/src/main/java/org/apache/camel/springboot/patch/extensions/ZipWagon.java
+++ b/tooling/redhat-patch-maven-plugin/src/main/java/org/apache/camel/springboot/patch/extensions/ZipWagon.java
@@ -86,8 +86,7 @@ public class ZipWagon extends StreamWagon {
             throw new MavenExecutionException("Can't create temporary directory to unzip " + zipFile, e);
         }
 
-        try {
-            ZipFile zf = new ZipFile(zipFile);
+        try (ZipFile zf = new ZipFile(zipFile)) {
             byte[] buf = new byte[16384];
             for (Enumeration<? extends ZipEntry> e = zf.entries(); e.hasMoreElements(); ) {
                 ZipEntry ze = e.nextElement();
@@ -141,7 +140,6 @@ public class ZipWagon extends StreamWagon {
                 target.getParentFile().setLastModified(ze.getTime());
                 target.setLastModified(ze.getTime());
             }
-            zf.close();
         } catch (IOException e) {
             throw new MavenExecutionException("Problem extracting data from " + zipFile, e);
         }

--- a/tooling/redhat-patch-maven-plugin/src/main/java/org/apache/camel/springboot/patch/extensions/ZipWagon.java
+++ b/tooling/redhat-patch-maven-plugin/src/main/java/org/apache/camel/springboot/patch/extensions/ZipWagon.java
@@ -141,6 +141,7 @@ public class ZipWagon extends StreamWagon {
                 target.getParentFile().setLastModified(ze.getTime());
                 target.setLastModified(ze.getTime());
             }
+            zf.close();
         } catch (IOException e) {
             throw new MavenExecutionException("Problem extracting data from " + zipFile, e);
         }


### PR DESCRIPTION
https://cov01.lab.eng.brq2.redhat.com/covscanhub/task/804406/log/camel-spring-boot-4.8.3.redhat-00009/scan-results-imp.err

This commit closes streams in two files that are only found in the productized branch - the rest of the fixes here to the OpenScanHub errors should go upstream