### PR TITLE
Remove dependencyManagement entries around hapi-fhir-core

### DIFF
--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -235,49 +235,6 @@
                 <version>${angus-mail-version}</version>
             </dependency>
 
-            <!-- overrides for ca.uhn.hapi.fhir:org.hl7.fhir.* -->
-            <dependency>
-                <groupId>ca.uhn.hapi.fhir</groupId>
-                <artifactId>org.hl7.fhir.dstu2</artifactId>
-                <version>${hapi-fhir-core-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>ca.uhn.hapi.fhir</groupId>
-                <artifactId>org.hl7.fhir.dstu2016may</artifactId>
-                <version>${hapi-fhir-core-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>ca.uhn.hapi.fhir</groupId>
-                <artifactId>org.hl7.fhir.dstu3</artifactId>
-                <version>${hapi-fhir-core-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>ca.uhn.hapi.fhir</groupId>
-                <artifactId>org.hl7.fhir.r4</artifactId>
-                <version>${hapi-fhir-core-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>ca.uhn.hapi.fhir</groupId>
-                <artifactId>org.hl7.fhir.r4b</artifactId>
-                <version>${hapi-fhir-core-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>ca.uhn.hapi.fhir</groupId>
-                <artifactId>org.hl7.fhir.r5</artifactId>
-                <version>${hapi-fhir-core-version}</version>
-                <exclusions>
-                <exclusion>
-                    <groupId>com.github.stephenc.jcip</groupId>
-                    <artifactId>jcip-annotations</artifactId>
-                </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>ca.uhn.hapi.fhir</groupId>
-                <artifactId>org.hl7.fhir.utilities</artifactId>
-                <version>${hapi-fhir-core-version}</version>
-            </dependency>
-
             <!-- upgrades for spring -->
             <dependency>
                 <groupId>org.springframework.security</groupId>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -235,49 +235,6 @@
                 <version>2.0.3</version>
             </dependency>
 
-            <!-- overrides for ca.uhn.hapi.fhir:org.hl7.fhir.* -->
-            <dependency>
-                <groupId>ca.uhn.hapi.fhir</groupId>
-                <artifactId>org.hl7.fhir.dstu2</artifactId>
-                <version>${hapi-fhir-core-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>ca.uhn.hapi.fhir</groupId>
-                <artifactId>org.hl7.fhir.dstu2016may</artifactId>
-                <version>${hapi-fhir-core-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>ca.uhn.hapi.fhir</groupId>
-                <artifactId>org.hl7.fhir.dstu3</artifactId>
-                <version>${hapi-fhir-core-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>ca.uhn.hapi.fhir</groupId>
-                <artifactId>org.hl7.fhir.r4</artifactId>
-                <version>${hapi-fhir-core-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>ca.uhn.hapi.fhir</groupId>
-                <artifactId>org.hl7.fhir.r4b</artifactId>
-                <version>${hapi-fhir-core-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>ca.uhn.hapi.fhir</groupId>
-                <artifactId>org.hl7.fhir.r5</artifactId>
-                <version>${hapi-fhir-core-version}</version>
-                <exclusions>
-                <exclusion>
-                    <groupId>com.github.stephenc.jcip</groupId>
-                    <artifactId>jcip-annotations</artifactId>
-                </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>ca.uhn.hapi.fhir</groupId>
-                <artifactId>org.hl7.fhir.utilities</artifactId>
-                <version>${hapi-fhir-core-version}</version>
-            </dependency>
-
             <!-- upgrades for spring -->
             <dependency>
                 <groupId>org.springframework.security</groupId>


### PR DESCRIPTION
Remove dependencyManagement entries around hapi-fhir-core; camel is now using hapi-fhir 7.6.1 and hapi-fhir-core entries are unnecessary and ${hapi-fhir-core-version} no longer exists