### PR TITLE
Need test for whether camel-yaml-io-starter is productized

### DIFF
--- a/tooling/camel-spring-boot-bom/pom.xml
+++ b/tooling/camel-spring-boot-bom/pom.xml
@@ -1921,7 +1921,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-yaml-io-starter</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.10.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>

--- a/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomGeneratorMojo.java
+++ b/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomGeneratorMojo.java
@@ -265,7 +265,7 @@ public class BomGeneratorMojo extends AbstractMojo {
         dep = new Dependency();
         dep.setGroupId("org.apache.camel.springboot");
         dep.setArtifactId("camel-yaml-io-starter");
-        dep.setVersion(project.getVersion());
+        dep.setVersion(productizedArtifacts.containsKey("camel-yaml-io-starter") ? "${project.version}" : camelCommunityVersion);
         outDependencies.add(dep);
         dep = new Dependency();
         dep.setGroupId("org.apache.camel.springboot");


### PR DESCRIPTION
I'll investigate further - but this is probably a merge issue I missed in creating branches in that camel-yaml-io-starter is not productized https://github.com/jboss-fuse/camel-spring-boot/blob/camel-spring-boot-4.10.0-branch/dsl-starter/pom.xml#L44 but is being set to the productized version, which caused a MRRC build break.

The fix here is to check whether it is a productized starter, like we do with all of the other dsl-starters.