### PR TITLE
CSB-6358 Add camel-observability-services and camel-ssh to productized starters; update camel / fuse-components versions

### DIFF
--- a/.mvn/excludes.txt
+++ b/.mvn/excludes.txt
@@ -151,7 +151,6 @@
 :camel-neo4j-starter
 :camel-nitrite-starter
 :camel-oaipmh-starter
-:camel-observability-services-starter
 :camel-observation-starter
 :camel-ognl-starter
 :camel-olingo2-starter
@@ -190,7 +189,6 @@
 :camel-snakeyaml-starter
 :camel-solr-starter
 :camel-springdoc-starter
-:camel-ssh-starter
 :camel-stax-starter
 :camel-stitch-starter
 :camel-stomp-starter

--- a/components-starter/pom.xml
+++ b/components-starter/pom.xml
@@ -340,7 +340,7 @@
     <module>camel-netty-starter</module>
     <!-- <module>camel-nitrite-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-oaipmh-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
-    <!-- <module>camel-observability-services-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
+    <module>camel-observability-services-starter</module>
     <!-- <module>camel-observation-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-ognl-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-olingo2-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
@@ -411,7 +411,7 @@
     <module>camel-spring-ws-starter</module>
     <!-- <module>camel-springdoc-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <module>camel-sql-starter</module>
-    <!-- <module>camel-ssh-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
+    <module>camel-ssh-starter</module>
     <!-- <module>camel-stax-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-stitch-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-stomp-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->

--- a/maintenance/pom.xml
+++ b/maintenance/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>spring-boot-parent</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.10.0-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/maintenance/redhat-camel-spring-boot-patch-metadata/pom.xml
+++ b/maintenance/redhat-camel-spring-boot-patch-metadata/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.redhat.camel.springboot.platform</groupId>
         <artifactId>redhat-camel-spring-boot-maintenance</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>redhat-camel-spring-boot-patch-metadata</artifactId>

--- a/maintenance/redhat-camel-spring-boot-patch-repository/pom.xml
+++ b/maintenance/redhat-camel-spring-boot-patch-repository/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.redhat.camel.springboot.platform</groupId>
         <artifactId>redhat-camel-spring-boot-maintenance</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.10.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>redhat-camel-spring-boot-patch-repository</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dependencies</artifactId>
-        <version>4.10.0.redhat-00003</version>
+        <version>4.10.0.redhat-00005</version>
     </parent>
 
     <groupId>org.apache.camel.springboot</groupId>
@@ -101,10 +101,10 @@
 
     <properties>
         <aalto-xml-version>1.3.2</aalto-xml-version>
-        <camel-cics.version>4.10.0.redhat-00004</camel-cics.version>
+        <camel-cics.version>4.10.0.redhat-00005</camel-cics.version>
         <camel-community-version>4.10.0</camel-community-version>
         <camel-kamelets-version>4.10.0.redhat-00002</camel-kamelets-version>
-        <camel-sap.version>4.10.0.redhat-00004</camel-sap.version>
+        <camel-sap.version>4.10.0.redhat-00005</camel-sap.version>
         <camel-spring-boot-community.version>4.10.0</camel-spring-boot-community.version>
         <cq-plugin.version>4.16.2</cq-plugin.version>
         <jakarta-el-version>6.0.1</jakarta-el-version>
@@ -134,7 +134,7 @@
         <spring-boot-version>3.4.2</spring-boot-version>
 
         <!-- Camel target version -->
-        <camel-version>4.10.0.redhat-00004</camel-version>
+        <camel-version>4.10.0.redhat-00005</camel-version>
 
         <!-- versions -->
         <aether-version>1.0.2.v20150114</aether-version>
@@ -149,7 +149,6 @@
         <maven-javadoc-plugin-version>3.11.2</maven-javadoc-plugin-version>
         <maven-surefire-plugin-version>3.5.2</maven-surefire-plugin-version>
         <mycila-license-version>4.6</mycila-license-version>
-        <plexus-component-metadata-plugin-version>2.1.1</plexus-component-metadata-plugin-version>
         <springdoc-version>2.2.0</springdoc-version>
         <surefire.version>${maven-surefire-plugin-version}</surefire.version>
         <swagger-parser-v3-version>2.1.10</swagger-parser-v3-version>

--- a/product/src/main/resources/required-productized-camel-artifacts.txt
+++ b/product/src/main/resources/required-productized-camel-artifacts.txt
@@ -102,6 +102,7 @@ camel-mybatis-starter
 camel-nats-starter
 camel-netty-starter
 camel-netty-http-starter
+camel-observability-services-starter
 camel-olingo4-starter
 camel-openapi-java-starter
 camel-opensearch-starter
@@ -134,6 +135,7 @@ camel-spring-rabbitmq-starter
 camel-spring-redis-starter
 camel-spring-security-starter
 camel-spring-ws-starter
+camel-ssh-starter
 camel-stub-starter
 camel-sql-starter
 camel-telegram-starter

--- a/tooling/camel-spring-boot-bom/pom.xml
+++ b/tooling/camel-spring-boot-bom/pom.xml
@@ -1301,7 +1301,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-observability-services-starter</artifactId>
-        <version>4.10.0</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -1686,7 +1686,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-ssh-starter</artifactId>
-        <version>4.10.0</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -295,17 +295,17 @@
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-debezium-maven-plugin</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-salesforce-maven-plugin</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-servicenow-maven-plugin</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -1540,7 +1540,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-observability-services-starter</artifactId>
-        <version>4.10.0</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -1915,7 +1915,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-ssh-starter</artifactId>
-        <version>4.10.0</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -2185,7 +2185,7 @@
       <dependency>
         <groupId>org.apache.camel.tests</groupId>
         <artifactId>org.apache.camel.tests.mock-javamail_1.7</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2200,18 +2200,18 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-allcomponents</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-amqp</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-api</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2251,12 +2251,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-attachments</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-avro</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2291,7 +2291,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-secrets-manager</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2306,12 +2306,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-cw</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ddb</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2341,7 +2341,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-kinesis</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2351,7 +2351,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-lambda</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2371,7 +2371,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-s3</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2381,12 +2381,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sns</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sqs</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2416,7 +2416,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-eventhubs</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2426,7 +2426,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-key-vault</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2436,12 +2436,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-servicebus</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-blob</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2451,7 +2451,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-queue</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2461,12 +2461,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base-engine</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2476,22 +2476,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean-validator</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-beanio</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bindy</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2516,7 +2516,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-browse</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2526,22 +2526,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cassandraql</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog-console</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog-lucene</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2566,7 +2566,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cli-connector</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2576,17 +2576,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloud</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloudevents</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cluster</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2606,12 +2606,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-componentdsl</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-console</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2621,12 +2621,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-controlbus</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2637,37 +2637,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-catalog</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-engine</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-languages</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-model</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-processor</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-reifier</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-xml</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2682,12 +2682,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cron</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-crypto</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2712,52 +2712,52 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-common</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-rest</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-soap</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-common</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-rest</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-soap</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-transport</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-transport</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataformat</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataset</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2822,7 +2822,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-direct</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2832,7 +2832,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-djl</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2857,12 +2857,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-modeline</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-support</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2877,12 +2877,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch-rest-client</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2892,12 +2892,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl-support</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2917,17 +2917,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir-api</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-file</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2942,7 +2942,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-flink</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2962,7 +2962,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ftp</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2987,7 +2987,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-bigquery</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3012,7 +3012,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-pubsub</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3022,7 +3022,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-secret-manager</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3042,7 +3042,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-graphql</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3052,17 +3052,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-groovy</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-grpc</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-gson</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3072,7 +3072,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hashicorp-vault</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3087,27 +3087,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-health</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hl7</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-base</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-common</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3167,17 +3167,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-common</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-embedded</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3202,32 +3202,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-avro</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-protobuf</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jacksonxml</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jasypt</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-java-joor-dsl</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3237,7 +3237,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jaxb</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3277,7 +3277,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jdbc</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3292,7 +3292,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jfr</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3307,12 +3307,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jira</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jms</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3332,17 +3332,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-joor</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jpa</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jq</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3352,7 +3352,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jslt</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3382,17 +3382,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonpath</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jt400</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jta</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3402,32 +3402,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kafka</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet-main</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-api</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-http</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3437,12 +3437,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kubernetes</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kudu</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3477,12 +3477,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-language</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ldap</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3497,12 +3497,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-log</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lra</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3522,37 +3522,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail-microsoft-oauth</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-main</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management-api</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mapstruct</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-master</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3562,27 +3562,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-micrometer</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-micrometer-prometheus</artifactId>
-        <version>4.10.0</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-config</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-fault-tolerance</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-health</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3597,22 +3597,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-minio</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mllp</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mock</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mongodb</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3632,12 +3632,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mybatis</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nats</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3647,12 +3647,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty-http</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3667,7 +3667,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-observability-services</artifactId>
-        <version>4.10.0</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3692,17 +3692,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4-api</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-java</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3717,7 +3717,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opensearch</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3727,7 +3727,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opentelemetry</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3737,12 +3737,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho-mqtt5</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3772,7 +3772,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3782,12 +3782,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-main</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-vertx</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3827,7 +3827,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-quartz</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3862,7 +3862,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ref</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3872,7 +3872,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-resilience4j</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3882,12 +3882,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest-openapi</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3917,12 +3917,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saga</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-salesforce</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3937,12 +3937,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saxon</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-scheduler</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3952,7 +3952,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-seda</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3967,7 +3967,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-servlet</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3987,12 +3987,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-slack</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smb</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4012,12 +4012,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-snmp</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-soap</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4027,72 +4027,72 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk-hec</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-batch</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-jdbc</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-ldap</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-main</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-rabbitmq</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-redis</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-security</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-ws</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-xml</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sql</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ssh</artifactId>
-        <version>4.10.0</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4122,12 +4122,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stub</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-support</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4152,7 +4152,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-telegram</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4162,12 +4162,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-junit5</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4177,7 +4177,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-spring-junit5</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4202,22 +4202,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-timer</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-maven</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-model</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-util</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4227,7 +4227,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tracing</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4242,12 +4242,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-undertow</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-undertow-spring-security</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4257,22 +4257,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util-json</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-validator</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-velocity</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4282,17 +4282,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-common</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-http</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-websocket</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4317,7 +4317,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-webhook</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4342,27 +4342,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xj</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-dsl</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-util</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxb</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4372,12 +4372,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp-util</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4392,37 +4392,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xpath</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt-saxon</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-common</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-deserializers</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-io</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4437,12 +4437,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zip-deflater</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zipfile</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4462,7 +4462,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>spi-annotations</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
@@ -4653,7 +4653,7 @@
       <dependency>
         <groupId>org.fusesource</groupId>
         <artifactId>camel-cics</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.fusesource</groupId>
@@ -4663,7 +4663,7 @@
       <dependency>
         <groupId>org.fusesource</groupId>
         <artifactId>camel-sap</artifactId>
-        <version>4.10.0.redhat-00004</version>
+        <version>4.10.0.redhat-00005</version>
       </dependency>
       <dependency>
         <groupId>org.fusesource</groupId>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -74,12 +74,12 @@
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-api</artifactId>
-                <version>4.10.0.redhat-00004</version>
+                <version>4.10.0.redhat-00005</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-support</artifactId>
-                <version>4.10.0.redhat-00004</version>
+                <version>4.10.0.redhat-00005</version>
             </dependency>
 
             <!-- Insert third party overrides here -->
@@ -289,7 +289,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.18.2.redhat-00002</version>
+                <version>2.18.2.redhat-00004</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -517,7 +517,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-bom</artifactId>
-                <version>4.1.0.rbac-redhat-00002</version>
+                <version>4.1.0.rbac-redhat-00004</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Added camel-observability-services and camel-ssh to the list of productized starters; updated the camel version so that the newly productized components are available