### PR TITLE
Downgrade maven in patch-maven-plugin to 3.8.6

### DIFF
--- a/tooling/redhat-patch-maven-plugin/pom.xml
+++ b/tooling/redhat-patch-maven-plugin/pom.xml
@@ -34,6 +34,10 @@
 
     <description>Maven plugin that adjusts dependencies according to patch/security metadata.</description>
 
+    <properties>
+        <maven-version>3.8.6</maven-version>
+    </properties>
+
     <dependencies>
 
         <!-- Maven -->


### PR DESCRIPTION
I think this will fix the issues we're seeing in trying to build from source - I think the issue here is that a productized maven-3.9.9 has not been released and MRRC does not seem to want to pick it up, but if we downgrade and build the patch-maven-plugin with 3.8.6, a productized version of that maven is available at maven.repository.redhat.com : 

https://maven.repository.redhat.com/ga/org/apache/maven/maven-embedder/3.8.6.redhat-00002/