### PR TITLE
Change bom ordering - netty-reactor-http after netty-bom

### DIFF
--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -132,12 +132,7 @@
                 <artifactId>logback-core</artifactId>
                 <version>${logback-version}</version>
             </dependency>
-            <!-- Override for reactor-netty-http -->
-            <dependency>
-                <groupId>io.projectreactor.netty</groupId>
-                <artifactId>reactor-netty-http</artifactId>
-                <version>${reactor-netty-version}</version>
-            </dependency>
+
 
             <!-- Override for org.json:json -->
             <dependency>
@@ -320,6 +315,13 @@
                 <version>${netty-version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <!-- Override for reactor-netty-http -->
+            <dependency>
+                <groupId>io.projectreactor.netty</groupId>
+                <artifactId>reactor-netty-http</artifactId>
+                <version>${reactor-netty-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/CSB-6544 shows inconsistent netty alignment - most netty artifacts were correctly aligned to the productized version of 4.1.119.Final, but a few straggling netty artifacts were aligned to a community 4.1.118.Final.     That is because reactor-netty-http shows up first in the bom. 

Move reactory-netty-http to after the netty-bom so the netty-bom takes precedence in the case of all netty artifacts.