### PR TITLE
adds MicroShift profile on archetype and jbang catalog

### DIFF
--- a/archetypes/camel-archetype-spring-boot/pom.xml
+++ b/archetypes/camel-archetype-spring-boot/pom.xml
@@ -35,6 +35,8 @@
 
     <properties>
          <archetype.test.settingsFile>src/test/resources/settings.xml</archetype.test.settingsFile> <!-- Needed to download camel-spring-boot snapshots -->
+         <skip.ocp.tests>true</skip.ocp.tests>
+         <skip.microshift.tests>true</skip.microshift.tests>
     </properties>
 
     <build>
@@ -70,5 +72,32 @@
             </testResource>
         </testResources>
     </build>
+
+    <profiles>
+        <profile>
+            <id>openshift</id>
+            <activation>
+                <property>
+                    <name>archetype-cluster</name>
+                    <value>openshift</value>
+                </property>
+            </activation>
+            <properties>
+                <skip.ocp.tests>false</skip.ocp.tests>
+            </properties>
+        </profile>
+        <profile>
+            <id>microshift</id>
+            <activation>
+                <property>
+                    <name>archetype-cluster</name>
+                    <value>microshift</value>
+                </property>
+            </activation>
+            <properties>
+                <skip.microshift.tests>false</skip.microshift.tests>
+            </properties>
+        </profile>
+    </profiles>
 
 </project>

--- a/archetypes/camel-archetype-spring-boot/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/camel-archetype-spring-boot/src/main/resources/archetype-resources/pom.xml
@@ -36,6 +36,7 @@
     <spring.boot-version>${spring-boot-version}</spring.boot-version>
     <surefire.plugin.version>3.5.0</surefire.plugin.version>
     <jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+    <jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
   </properties>
 
   <dependencyManagement>
@@ -170,6 +171,38 @@
                 <goals>
                   <goal>resource</goal>
                   <goal>build</goal>
+                  <goal>apply</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>microshift</id>
+      <properties>
+        <jkube.build.strategy>jib</jkube.build.strategy>
+        <jkube.docker.registry>myregistry.io/myorg</jkube.docker.registry>
+        <jkube.docker.username>myregistry-user</jkube.docker.username>
+        <jkube.docker.password>myregistry-password</jkube.docker.password>
+        <!-- optional -->
+        <jkube.imagePullPolicy>Always</jkube.imagePullPolicy>
+        <jkube.docker.push.retries>3</jkube.docker.push.retries>
+      </properties>
+      <build>
+        <defaultGoal>install</defaultGoal>
+        <plugins>
+          <plugin>
+            <groupId>org.eclipse.jkube</groupId>
+            <artifactId>openshift-maven-plugin</artifactId>
+            <version>${openshift-maven-plugin-version}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>resource</goal>
+                  <goal>build</goal>
+                  <goal>push</goal>
                   <goal>apply</goal>
                 </goals>
               </execution>

--- a/archetypes/camel-archetype-spring-boot/src/main/resources/archetype-resources/readme.adoc
+++ b/archetypes/camel-archetype-spring-boot/src/main/resources/archetype-resources/readme.adoc
@@ -28,6 +28,27 @@ You can run unit test of this example using
 
     mvn clean test
 
+== How to deploy on OpenShift
+
+You can deploy on OpenShift using
+
+    mvn clean install -P openshift
+
+the application will be built and deployed on the current project on the logged-in OpenShift cluster, so please be sure you are correctly logged in before running the command
+
+== How to deploy on MicroShift
+
+You can deploy on MicroShift using
+
+    mvn clean install -P microshift -Djkube.docker.registry=[docker registry]
+
+the application will be deployed on the current project on the logged-in MicroShift cluster, so please be sure you are correctly logged in before running the command. Since MicroShift doesn't have an internal OCI registry, it is necessary to push/pull images externally, so a docker registry is needed (eg: `quay.io/my-organization` ) moreover if the registry is private the command requires the credentials for push and/or pull - https://eclipse.dev/jkube/docs/openshift-maven-plugin/#_pull_vs_push_authentication[documentation] eg:
+
+    mvn clean install -P microshift \
+        -Djkube.docker.registry=quay.io/my-organization \
+        -Djkube.docker.username=myuser \
+        -Djkube.docker.password=mypassword
+
 == More information
 
 You can find more information about Apache Camel at the website: http://camel.apache.org/

--- a/archetypes/camel-archetype-spring-boot/src/test/resources/projects/build-it/archetype.properties
+++ b/archetypes/camel-archetype-spring-boot/src/test/resources/projects/build-it/archetype.properties
@@ -18,11 +18,3 @@ groupId=org.apache.camel.archetypes.archetypeIT.camel-archetype-spring-boot
 artifactId=build-it
 version=0.0.1
 package=org.apache.camel.archetypes.archetypeIT
-
-# TODO: Remove these, after https://issues.apache.org/jira/browse/ARCHETYPE-574 fixed
-camel-spring-boot-version=${project.version}
-logback-version=${logback-version}
-maven-compiler-plugin-version=${maven-compiler-plugin-version}
-maven-resources-plugin-version=${maven-resources-plugin-version}
-spring-boot-version=${spring-boot-version}
-openshift-maven-plugin-version=${openshift-maven-plugin-version}

--- a/archetypes/camel-archetype-spring-boot/src/test/resources/projects/deploy-on-microshift/archetype.properties
+++ b/archetypes/camel-archetype-spring-boot/src/test/resources/projects/deploy-on-microshift/archetype.properties
@@ -14,7 +14,7 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
-groupId=org.apache.camel.archetypes.archetypeIT.camel-archetype-spring-boot
-artifactId=run-it
+groupId=camel-archetype-spring-boot
+artifactId=deploy-on-microshift
 version=0.0.1
 package=org.apache.camel.archetypes.archetypeIT

--- a/archetypes/camel-archetype-spring-boot/src/test/resources/projects/deploy-on-microshift/goal.txt
+++ b/archetypes/camel-archetype-spring-boot/src/test/resources/projects/deploy-on-microshift/goal.txt
@@ -1,0 +1,1 @@
+install -Dmaven.test.skip=true -P microshift -Djkube.skip=${skip.microshift.tests} -Djkube.docker.registry=${jkube.docker.registry} -Djkube.docker.username=${jkube.docker.username} -Djkube.docker.password=${jkube.docker.password}

--- a/archetypes/camel-archetype-spring-boot/src/test/resources/projects/deploy-on-ocp/archetype.properties
+++ b/archetypes/camel-archetype-spring-boot/src/test/resources/projects/deploy-on-ocp/archetype.properties
@@ -14,7 +14,7 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
-groupId=org.apache.camel.archetypes.archetypeIT.camel-archetype-spring-boot
-artifactId=run-it
+groupId=camel-archetype-spring-boot
+artifactId=deploy-on-ocp
 version=0.0.1
 package=org.apache.camel.archetypes.archetypeIT

--- a/archetypes/camel-archetype-spring-boot/src/test/resources/projects/deploy-on-ocp/goal.txt
+++ b/archetypes/camel-archetype-spring-boot/src/test/resources/projects/deploy-on-ocp/goal.txt
@@ -1,0 +1,1 @@
+install -Dmaven.test.skip=true -P openshift -Djkube.skip=${skip.ocp.tests}

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/catalog/camel-jbang/spring-boot-pom.tmpl
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/catalog/camel-jbang/spring-boot-pom.tmpl
@@ -17,6 +17,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<spring.boot-version>{{ .SpringBootVersion }}</spring.boot-version>
 		<surefire.plugin.version>3.5.0</surefire.plugin.version>
+		<jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
 		<jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
 		<camel.spring.boot-version>{{ .CamelSpringBootVersion }}</camel.spring.boot-version>
 {{ .BuildProperties }}
@@ -122,6 +123,38 @@
 									<goal>resource</goal>
 									<goal>build</goal>
 									<goal>apply</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>microshift</id>
+			<properties>
+				<jkube.build.strategy>jib</jkube.build.strategy>
+ 				<jkube.docker.registry>myregistry.io/myorg</jkube.docker.registry>
+				<jkube.docker.username>myregistry-user</jkube.docker.username>
+				<jkube.docker.password>myregistry-password</jkube.docker.password>
+				<!-- optional -->
+				<jkube.imagePullPolicy>Always</jkube.imagePullPolicy>
+				<jkube.docker.push.retries>3</jkube.docker.push.retries>
+			</properties>
+			<build>
+				<defaultGoal>install</defaultGoal>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.jkube</groupId>
+						<artifactId>openshift-maven-plugin</artifactId>
+						<version>${openshift-maven-plugin-version}</version>
+						<executions>
+							<execution>
+								<goals>
+									<goal>resource</goal>
+								  <goal>build</goal>
+								  <goal>push</goal>
+								  <goal>apply</goal>
 								</goals>
 							</execution>
 						</executions>


### PR DESCRIPTION
Adds MicroShift profile to deploy on MicroShift, the following properties are required to push the image on remote registry:

- `jkube.docker.registry`
- `jkube.docker.username`
- `jkube.docker.password`