### PR TITLE
Build is failing missing camel-yaml-io-starter - need community version

### DIFF
--- a/tooling/camel-spring-boot-bom/pom.xml
+++ b/tooling/camel-spring-boot-bom/pom.xml
@@ -1921,7 +1921,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-yaml-io-starter</artifactId>
-        <version>4.10.3-SNAPSHOT</version>
+        <version>4.10.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>

--- a/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomGeneratorMojo.java
+++ b/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomGeneratorMojo.java
@@ -265,7 +265,7 @@ public class BomGeneratorMojo extends AbstractMojo {
         dep = new Dependency();
         dep.setGroupId("org.apache.camel.springboot");
         dep.setArtifactId("camel-yaml-io-starter");
-        dep.setVersion(project.getVersion());
+        dep.setVersion(productizedArtifacts.containsKey("camel-yaml-io-starter") ? "${project.version}" : camelCommunityVersion);
         outDependencies.add(dep);
         dep = new Dependency();
         dep.setGroupId("org.apache.camel.springboot");


### PR DESCRIPTION
We need to use the check on whether camel-yaml-io-starter is productized - MRRC generation is failing because it has camel-yaml-io-starter miscatagorized as supported

https://jenkins-cpaas-camel-spring-boot.apps.cpaas-poc.r6c9.p1.openshiftapps.com/job/release-4.10.3/job/camel-spring-boot/job/camel-spring-boot-pnc/job/camel-spring-boot/1/artifact/bacon-ca1a769e-a69d-4494-80e7-8c50dc31e094.json