### PR TITLE
Add a uname -a to the Jenkinsfile so we know what host the PR tests ran on

### DIFF
--- a/Jenkinsfile.redhat
+++ b/Jenkinsfile.redhat
@@ -55,7 +55,7 @@ pipeline {
             steps {
                 configFileProvider([configFile(fileId: 'fuse-maven-settings', variable: 'MAVEN_SETTINGS')]) {
                     script {
-                        spring_boot_itests_result = sh script: "./mvnw $MAVEN_PARAMS -Dmaven.test.failure.ignore=true clean install", returnStatus: true
+                        spring_boot_itests_result = sh script: "uname -a; ./mvnw $MAVEN_PARAMS -Dmaven.test.failure.ignore=true clean install", returnStatus: true
                     }
                 }
             }


### PR DESCRIPTION
https://jenkins-csb-fuse-ci.dno.corp.redhat.com/blue/organizations/jenkins/CamelSpringBoot%2Fcamel-spring-boot/detail/PR-536/1/pipeline failed because the disk filled up during a test - I'd like to add a uname -a to the log so we know what Jenkins host ran a test run and so we can terminate it / respawn a new one if it fills up.