### PR TITLE
Close stream and fileReader before resource leak

### DIFF
--- a/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/RequiredProductizedArtifactsReader.java
+++ b/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/RequiredProductizedArtifactsReader.java
@@ -34,10 +34,8 @@ import java.util.HashMap;
     public static HashMap<String, Boolean> getProductizedCSBArtifacts(File requiredFile) {
         HashMap<String, Boolean> map = new HashMap<>();
 
-        try {
-            FileReader fileReader = new FileReader(requiredFile);
-            BufferedReader br = new BufferedReader(fileReader);
-
+        try (FileReader fileReader = new FileReader(requiredFile);
+        BufferedReader br = new BufferedReader(fileReader)) {
             String line;
             while ((line = br.readLine()) != null) {
                 if (line.startsWith("#")) {


### PR DESCRIPTION
Close stream and fileReader before resource leak

Reported by coverity : 
Error: RESOURCE_LEAK ([CWE-404](https://cwe.mitre.org/data/definitions/404.html)): [[#def1]]