### PR TITLE
Move jetty-bom import higher than artemis-bom so we use jetty 12.0.19 productized; use most recent camel

### DIFF
--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/constant.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/constant.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.10.3.redhat-00002",
+    "version": "4.10.3.redhat-00015",
     "modelName": "constant",
     "modelJavaType": "org.apache.camel.model.language.ConstantExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/csimple.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/csimple.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.10.3.redhat-00002",
+    "version": "4.10.3.redhat-00015",
     "modelName": "csimple",
     "modelJavaType": "org.apache.camel.model.language.CSimpleExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/exchangeProperty.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/exchangeProperty.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.10.3.redhat-00002",
+    "version": "4.10.3.redhat-00015",
     "modelName": "exchangeProperty",
     "modelJavaType": "org.apache.camel.model.language.ExchangePropertyExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/file.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/file.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.10.3.redhat-00002",
+    "version": "4.10.3.redhat-00015",
     "modelName": "simple",
     "modelJavaType": "org.apache.camel.model.language.SimpleExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/header.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/header.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.10.3.redhat-00002",
+    "version": "4.10.3.redhat-00015",
     "modelName": "header",
     "modelJavaType": "org.apache.camel.model.language.HeaderExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/ref.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/ref.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.10.3.redhat-00002",
+    "version": "4.10.3.redhat-00015",
     "modelName": "ref",
     "modelJavaType": "org.apache.camel.model.language.RefExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/simple.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/simple.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.10.3.redhat-00002",
+    "version": "4.10.3.redhat-00015",
     "modelName": "simple",
     "modelJavaType": "org.apache.camel.model.language.SimpleExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/tokenize.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/tokenize.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.10.3.redhat-00002",
+    "version": "4.10.3.redhat-00015",
     "modelName": "tokenize",
     "modelJavaType": "org.apache.camel.model.language.TokenizerExpression"
   },

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/variable.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/languages/variable.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-core-languages",
-    "version": "4.10.3.redhat-00002",
+    "version": "4.10.3.redhat-00015",
     "modelName": "variable",
     "modelJavaType": "org.apache.camel.model.language.VariableExpression"
   },

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dependencies</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
     </parent>
 
     <groupId>org.apache.camel.springboot</groupId>
@@ -134,7 +134,7 @@
         <spring-boot-version>3.4.5</spring-boot-version>
 
         <!-- Camel target version -->
-        <camel-version>4.10.3.redhat-00015</camel-version>
+        <camel-version>4.10.3.redhat-00016</camel-version>
 
         <!-- versions -->
         <aether-version>1.0.2.v20150114</aether-version>

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -295,17 +295,17 @@
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-debezium-maven-plugin</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-salesforce-maven-plugin</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-servicenow-maven-plugin</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -2160,7 +2160,7 @@
       <dependency>
         <groupId>org.apache.camel.tests</groupId>
         <artifactId>org.apache.camel.tests.mock-javamail_1.7</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2175,18 +2175,18 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-allcomponents</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-amqp</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-api</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2226,12 +2226,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-attachments</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-avro</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2266,7 +2266,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-secrets-manager</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2281,12 +2281,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-cw</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ddb</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2316,7 +2316,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-kinesis</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2326,7 +2326,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-lambda</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2346,7 +2346,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-s3</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2356,12 +2356,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sns</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sqs</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2391,7 +2391,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-eventhubs</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2401,7 +2401,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-key-vault</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2411,12 +2411,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-servicebus</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-blob</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2426,7 +2426,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-queue</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2436,12 +2436,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base-engine</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2451,22 +2451,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean-validator</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-beanio</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bindy</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2491,7 +2491,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-browse</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2501,22 +2501,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cassandraql</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog-console</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog-lucene</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2541,7 +2541,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cli-connector</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2551,17 +2551,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloud</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloudevents</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cluster</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2581,12 +2581,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-componentdsl</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-console</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2596,12 +2596,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-controlbus</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2612,37 +2612,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-catalog</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-engine</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-languages</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-model</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-processor</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-reifier</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-xml</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2657,12 +2657,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cron</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-crypto</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2687,52 +2687,52 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-common</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-rest</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-soap</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-common</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-rest</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-soap</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-transport</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-transport</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataformat</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataset</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2797,7 +2797,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-direct</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2807,7 +2807,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-djl</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2832,12 +2832,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-modeline</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-support</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2852,12 +2852,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch-rest-client</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2867,12 +2867,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl-support</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2892,17 +2892,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir-api</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-file</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2917,7 +2917,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-flink</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2937,7 +2937,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ftp</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2962,7 +2962,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-bigquery</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2987,7 +2987,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-pubsub</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2997,7 +2997,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-secret-manager</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3017,7 +3017,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-graphql</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3027,17 +3027,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-groovy</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-grpc</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-gson</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3047,7 +3047,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hashicorp-vault</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3062,27 +3062,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-health</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hl7</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-base</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-common</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3142,17 +3142,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-common</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-embedded</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3177,32 +3177,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-avro</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-protobuf</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jacksonxml</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jasypt</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-java-joor-dsl</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3212,32 +3212,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jaxb</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbang-console</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbang-core</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbang-main</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbang-plugin-generate</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbang-plugin-kubernetes</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3252,7 +3252,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jdbc</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3267,7 +3267,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jfr</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3282,12 +3282,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jira</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jms</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3307,17 +3307,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-joor</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jpa</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jq</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3327,7 +3327,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jslt</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3357,17 +3357,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonpath</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jt400</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jta</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3377,32 +3377,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kafka</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet-main</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-api</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-http</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3412,12 +3412,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kubernetes</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kudu</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3452,12 +3452,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-language</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ldap</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3472,12 +3472,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-log</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lra</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3497,37 +3497,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail-microsoft-oauth</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-main</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management-api</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mapstruct</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-master</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3537,27 +3537,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-micrometer</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-micrometer-prometheus</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-config</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-fault-tolerance</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-health</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3572,22 +3572,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-minio</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mllp</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mock</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mongodb</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3607,12 +3607,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mybatis</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nats</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3622,12 +3622,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty-http</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3642,7 +3642,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-observability-services</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3667,22 +3667,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4-api</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-java</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-rest-dsl-generator</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3692,7 +3692,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opensearch</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3702,7 +3702,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opentelemetry</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3712,12 +3712,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho-mqtt5</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3747,7 +3747,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3757,12 +3757,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-main</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-vertx</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3802,7 +3802,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-quartz</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3837,7 +3837,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ref</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3847,22 +3847,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-resilience4j</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-resourceresolver-github</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest-openapi</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3892,12 +3892,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saga</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-salesforce</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3912,12 +3912,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saxon</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-scheduler</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3927,7 +3927,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-seda</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3942,7 +3942,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-servlet</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3962,17 +3962,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-slack</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smb</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smooks</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3987,12 +3987,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-snmp</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-soap</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4002,72 +4002,72 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk-hec</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-batch</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-jdbc</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-ldap</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-main</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-rabbitmq</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-redis</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-security</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-ws</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-xml</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sql</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ssh</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4097,12 +4097,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stub</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-support</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4127,7 +4127,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-telegram</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4137,12 +4137,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-junit5</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4152,7 +4152,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-spring-junit5</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4177,22 +4177,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-timer</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-maven</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-model</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-util</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4202,7 +4202,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tracing</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4217,12 +4217,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-undertow</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-undertow-spring-security</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4232,22 +4232,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util-json</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-validator</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-velocity</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4257,17 +4257,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-common</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-http</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-websocket</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4292,7 +4292,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-webhook</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4317,27 +4317,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xj</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-dsl</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-util</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxb</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4347,12 +4347,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp-util</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4367,37 +4367,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xpath</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt-saxon</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-common</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-deserializers</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-io</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4412,12 +4412,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zip-deflater</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zipfile</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4437,7 +4437,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>spi-annotations</artifactId>
-        <version>4.10.3.redhat-00015</version>
+        <version>4.10.3.redhat-00016</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
@@ -4613,12 +4613,12 @@
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-utils</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.2.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-xml</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.1.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jkube</groupId>

--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -246,6 +246,14 @@
                 <scope>import</scope>
             </dependency>
            
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-bom</artifactId>
+                <version>${jetty-version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <!-- Using artemis-bom, see CSB-5363 -->
             <dependency>
                 <groupId>org.apache.activemq</groupId>
@@ -278,14 +286,6 @@
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
                 <version>${reactor-netty-version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-bom</artifactId>
-                <version>${jetty-version}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
 
             <dependency>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -74,12 +74,12 @@
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-api</artifactId>
-                <version>4.10.3.redhat-00015</version>
+                <version>4.10.3.redhat-00016</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-support</artifactId>
-                <version>4.10.3.redhat-00015</version>
+                <version>4.10.3.redhat-00016</version>
             </dependency>
 
             <!-- Insert third party overrides here -->
@@ -246,11 +246,19 @@
                 <scope>import</scope>
             </dependency>
            
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-bom</artifactId>
+                <version>12.0.19.redhat-00002</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <!-- Using artemis-bom, see CSB-5363 -->
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>artemis-bom</artifactId>
-                <version>2.33.0.redhat-00017</version>
+                <version>2.40.0.redhat-00003</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -278,14 +286,6 @@
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
                 <version>1.2.2</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-bom</artifactId>
-                <version>12.0.19.redhat-00001</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
 
             <dependency>
@@ -519,7 +519,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-bom</artifactId>
-                <version>4.1.1.rhbac-redhat-00011</version>
+                <version>4.1.1.rhbac-redhat-00012</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Move jetty-bom import higher than artemis-bom so we use jetty 12.0.19 productized; use most recent camel