### PR TITLE
Disable large request from platform http certification test

### DIFF
--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCertificationTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCertificationTest.java
@@ -45,6 +45,7 @@ import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 import org.apache.camel.util.IOHelper;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -296,6 +297,7 @@ public class SpringBootPlatformHttpCertificationTest extends PlatformHttpBase {
     CamelContext camelContext;
 
     @Test
+    @Disabled
     @DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
             disabledReason = "File too large for Apache CI")
     void streamingWithLargeRequestAndResponseBody() throws Exception {


### PR DESCRIPTION
This test has been troublesome and is disabled at apache CI, try disabling for our CI as well

Test is failing here : https://jenkins-csb-fuse-ci.dno.corp.redhat.com/blue/organizations/jenkins/CamelSpringBoot%2Fcamel-spring-boot/detail/PR-550/1/pipeline