### PR TITLE
Add override for PG jdbc driver

### DIFF
--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -116,6 +116,13 @@
                 <artifactId>guava</artifactId>
                 <version>${guava-version}</version>
             </dependency>
+            <!-- Override for PG JDBC -->
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${pgjdbc-driver-version}</version>
+            </dependency>
+
             <!-- Overrides for logback -->
             <dependency>
                 <groupId>ch.qos.logback</groupId>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -116,6 +116,13 @@
                 <artifactId>guava</artifactId>
                 <version>33.4.0.jre-redhat-00001</version>
             </dependency>
+            <!-- Override for PG JDBC -->
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>42.7.5</version>
+            </dependency>
+
             <!-- Overrides for logback -->
             <dependency>
                 <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
https://github.com/jboss-fuse/camel/pull/2809 upgrades the pgjdbc-driver-version property in camel-parent to 42.7.7 but the use of org.postgresql:postgresql is in camel-pg-replication-slot - which is an unsupported component.     We need an override for the version change to take effect in the dependency tree.