### PR TITLE
Add camel-rest-openapi-starter to list of productized starters

### DIFF
--- a/.mvn/excludes.txt
+++ b/.mvn/excludes.txt
@@ -172,7 +172,6 @@
 :camel-quickfix-starter
 :camel-reactive-streams-starter
 :camel-reactor-starter
-:camel-rest-openapi-starter
 :camel-robotframework-starter
 :camel-rocketmq-starter
 :camel-rss-starter

--- a/components-starter/pom.xml
+++ b/components-starter/pom.xml
@@ -372,7 +372,7 @@
     <!-- <module>camel-reactor-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <module>camel-ref-starter</module>
     <module>camel-resilience4j-starter</module>
-    <!-- <module>camel-rest-openapi-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
+    <module>camel-rest-openapi-starter</module>
     <module>camel-rest-starter</module>
     <!-- <module>camel-robotframework-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-rocketmq-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->

--- a/product/src/main/resources/required-productized-camel-artifacts.txt
+++ b/product/src/main/resources/required-productized-camel-artifacts.txt
@@ -113,6 +113,7 @@ camel-platform-http-starter
 camel-quartz-starter
 camel-ref-starter
 camel-rest-starter
+camel-rest-openapi-starter
 camel-resilience4j-starter
 camel-saga-starter
 camel-salesforce-starter

--- a/tooling/camel-spring-boot-bom/pom.xml
+++ b/tooling/camel-spring-boot-bom/pom.xml
@@ -1431,7 +1431,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-rest-openapi-starter</artifactId>
-        <version>4.10.3</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -1675,7 +1675,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-rest-openapi-starter</artifactId>
-        <version>4.10.3</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>


### PR DESCRIPTION
In researching the camel-springboot-examples that should be removed because they have unsupported starters in them, it was discovered that camel-rest-openapi-starter wasn't included in the list of supported starters even though the camel-rest-openapi component is being productized in camel.

Need to productize this starter.