### PR TITLE
Cherry pick over a number of commits that went into camel-4.10.3-branch that we need

### DIFF
--- a/.mvn/excludes.txt
+++ b/.mvn/excludes.txt
@@ -172,7 +172,6 @@
 :camel-quickfix-starter
 :camel-reactive-streams-starter
 :camel-reactor-starter
-:camel-rest-openapi-starter
 :camel-robotframework-starter
 :camel-rocketmq-starter
 :camel-rss-starter
@@ -225,5 +224,10 @@
 :camel-zookeeper-cluster-service-starter
 :camel-zookeeper-master-starter
 :camel-zookeeper-starter
+:dependency-management-example
+:dependency-management-example-module1
 :docs
+:redhat-camel-spring-boot-maintenance
+:redhat-camel-spring-boot-patch-metadata
+:redhat-camel-spring-boot-patch-repository
 :tests

--- a/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/components/rest-openapi.json
+++ b/catalog/camel-catalog-provider-springboot/src/main/resources/org/apache/camel/springboot/catalog/components/rest-openapi.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel.springboot",
     "artifactId": "camel-rest-openapi-starter",
-    "version": "4.10.6",
+    "version": "4.10.6-SNAPSHOT",
     "scheme": "rest-openapi",
     "extendsScheme": "",
     "syntax": "rest-openapi:specificationUri#operationId",

--- a/components-starter/camel-core-starter/src/main/docs/core.json
+++ b/components-starter/camel-core-starter/src/main/docs/core.json
@@ -656,7 +656,7 @@
     {
       "name": "camel.resilience4j.throw-exception-when-half-open-or-open-state",
       "type": "java.lang.Boolean",
-      "description": "Whether to throw io.github.resilience4j.circuitbreaker.CallNotPermittedException when the call is rejected due circuit breaker is half open or open.",
+      "description": "Whether to throw io.github.resilience4j.circuitbreaker.CallNotPermittedException when the call is rejected due circuit breaker is half open (and was not attempted but rejected immediately) or open (always rejected). This option is only in use when there is NOT a fallback configured on the circuit breaker. When there is a fallback then the fallback is always executed and CallNotPermittedException is not thrown.",
       "sourceType": "org.apache.camel.model.springboot.Resilience4jConfigurationDefinitionProperties",
       "defaultValue": false
     },

--- a/components-starter/camel-core-starter/src/main/java/org/apache/camel/model/springboot/Resilience4jConfigurationDefinitionCommon.java
+++ b/components-starter/camel-core-starter/src/main/java/org/apache/camel/model/springboot/Resilience4jConfigurationDefinitionCommon.java
@@ -54,7 +54,11 @@ public class Resilience4jConfigurationDefinitionCommon {
     /**
      * Whether to throw
      * io.github.resilience4j.circuitbreaker.CallNotPermittedException when the
-     * call is rejected due circuit breaker is half open or open.
+     * call is rejected due circuit breaker is half open (and was not attempted
+     * but rejected immediately) or open (always rejected). This option is only
+     * in use when there is NOT a fallback configured on the circuit breaker.
+     * When there is a fallback then the fallback is always executed and
+     * CallNotPermittedException is not thrown.
      */
     private Boolean throwExceptionWhenHalfOpenOrOpenState = false;
     /**

--- a/components-starter/camel-kafka-starter/src/test/java/org/apache/camel/component/kafka/integration/KafkaProducerFullIT.java
+++ b/components-starter/camel-kafka-starter/src/test/java/org/apache/camel/component/kafka/integration/KafkaProducerFullIT.java
@@ -82,24 +82,24 @@ public class KafkaProducerFullIT extends BaseEmbeddedKafkaTestSupport {
     private static KafkaConsumer<String, String> stringsConsumerConn;
     private static KafkaConsumer<byte[], byte[]> bytesConsumerConn;
 
-    private final String toStrings = "kafka:" + TOPIC_STRINGS + "?requestRequiredAcks=-1";
+    private final String toStrings = "kafka:" + TOPIC_STRINGS + "?requestRequiredAcks=-1&recordMetadata=true";
 
-    private final String toStrings2 = "kafka:" + TOPIC_STRINGS + "?requestRequiredAcks=-1&partitionKey=0";
+    private final String toStrings2 = "kafka:" + TOPIC_STRINGS + "?requestRequiredAcks=-1&partitionKey=0&recordMetadata=true";
 
     private final String toStringsWithInterceptor = "kafka:" + TOPIC_INTERCEPTED + "?requestRequiredAcks=-1"
-            + "&interceptorClasses=org.apache.camel.component.kafka.integration.MockProducerInterceptor";
+            + "&interceptorClasses=org.apache.camel.component.kafka.integration.MockProducerInterceptor&recordMetadata=true";
 
     @EndpointInject("mock:kafkaAck")
     private MockEndpoint mockEndpoint;
 
     private final String toBytes = "kafka:" + TOPIC_BYTES + "?requestRequiredAcks=-1"
             + "&valueSerializer=org.apache.kafka.common.serialization.ByteArraySerializer&"
-            + "keySerializer=org.apache.kafka.common.serialization.ByteArraySerializer";
+            + "keySerializer=org.apache.kafka.common.serialization.ByteArraySerializer&recordMetadata=true";
 
-    private final String toPropagatedHeaders = "kafka:" + TOPIC_PROPAGATED_HEADERS + "?requestRequiredAcks=-1";
+    private final String toPropagatedHeaders = "kafka:" + TOPIC_PROPAGATED_HEADERS + "?requestRequiredAcks=-1&recordMetadata=true";
 
     private final String toNoRecordSpecificHeaders = "kafka:" + TOPIC_NO_RECORD_SPECIFIC_HEADERS
-            + "?requestRequiredAcks=-1";
+            + "?requestRequiredAcks=-1&recordMetadata=true";
 
     @Produce("direct:startStrings")
     private ProducerTemplate stringsTemplate;

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCertificationTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCertificationTest.java
@@ -44,6 +44,7 @@ import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 import org.apache.camel.util.IOHelper;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -295,6 +296,7 @@ public class SpringBootPlatformHttpCertificationTest extends PlatformHttpBase {
     CamelContext camelContext;
 
     @Test
+    @Disabled
     @DisabledIfSystemProperty(named = "ci.env.name", matches = "apache.org",
             disabledReason = "File too large for Apache CI")
     void streamingWithLargeRequestAndResponseBody() throws Exception {

--- a/components-starter/pom.xml
+++ b/components-starter/pom.xml
@@ -372,7 +372,7 @@
     <!-- <module>camel-reactor-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <module>camel-ref-starter</module>
     <module>camel-resilience4j-starter</module>
-    <!-- <module>camel-rest-openapi-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
+    <module>camel-rest-openapi-starter</module>
     <module>camel-rest-starter</module>
     <!-- <module>camel-robotframework-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-rocketmq-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->

--- a/maintenance/pom.xml
+++ b/maintenance/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>spring-boot-parent</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.10.6-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/maintenance/redhat-camel-spring-boot-patch-metadata/pom.xml
+++ b/maintenance/redhat-camel-spring-boot-patch-metadata/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.redhat.camel.springboot.platform</groupId>
         <artifactId>redhat-camel-spring-boot-maintenance</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>redhat-camel-spring-boot-patch-metadata</artifactId>

--- a/maintenance/redhat-camel-spring-boot-patch-repository/pom.xml
+++ b/maintenance/redhat-camel-spring-boot-patch-repository/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.redhat.camel.springboot.platform</groupId>
         <artifactId>redhat-camel-spring-boot-maintenance</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.10.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>redhat-camel-spring-boot-patch-repository</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,6 @@
         <org-json-json-version>20231013</org-json-json-version>
         <parsson-version>1.0.5</parsson-version>
         <perfmark-version>0.27.0</perfmark-version>
-        <plexus-component-metadata-plugin-version>2.1.1</plexus-component-metadata-plugin-version>
         <snappy-java-version>1.1.10.7</snappy-java-version>
         <tomcat-version>10.1.42</tomcat-version>
         <woodstox-stax2-api-version>4.2.1</woodstox-stax2-api-version>

--- a/product/src/main/resources/required-productized-camel-artifacts.txt
+++ b/product/src/main/resources/required-productized-camel-artifacts.txt
@@ -113,6 +113,7 @@ camel-platform-http-starter
 camel-quartz-starter
 camel-ref-starter
 camel-rest-starter
+camel-rest-openapi-starter
 camel-resilience4j-starter
 camel-saga-starter
 camel-salesforce-starter

--- a/tooling/camel-spring-boot-bom/pom.xml
+++ b/tooling/camel-spring-boot-bom/pom.xml
@@ -755,11 +755,6 @@
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>camel-groovy-dsl-starter</artifactId>
-        <version>4.10.6</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-groovy-starter</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -1010,17 +1005,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>camel-js-dsl-starter</artifactId>
-        <version>4.10.6</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-jsch-starter</artifactId>
-        <version>4.10.6</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>camel-jsh-dsl-starter</artifactId>
         <version>4.10.6</version>
       </dependency>
       <dependency>
@@ -1070,11 +1055,6 @@
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>camel-k-starter</artifactId>
-        <version>4.10.6</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-kafka-starter</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -1086,16 +1066,6 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-knative-starter</artifactId>
-        <version>4.10.6</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>camel-kotlin-api-starter</artifactId>
-        <version>4.10.6</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>camel-kotlin-dsl-starter</artifactId>
         <version>4.10.6</version>
       </dependency>
       <dependency>
@@ -1461,7 +1431,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-rest-openapi-starter</artifactId>
-        <version>4.10.6</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -1921,7 +1891,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-yaml-io-starter</artifactId>
-        <version>4.10.6-SNAPSHOT</version>
+        <version>4.10.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -999,11 +999,6 @@
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>camel-groovy-dsl-starter</artifactId>
-        <version>4.10.6</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-groovy-starter</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -1254,17 +1249,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>camel-js-dsl-starter</artifactId>
-        <version>4.10.6</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-jsch-starter</artifactId>
-        <version>4.10.6</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>camel-jsh-dsl-starter</artifactId>
         <version>4.10.6</version>
       </dependency>
       <dependency>
@@ -1314,11 +1299,6 @@
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>camel-k-starter</artifactId>
-        <version>4.10.6</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-kafka-starter</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -1330,11 +1310,6 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-knative-starter</artifactId>
-        <version>4.10.6</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>camel-kotlin-dsl-starter</artifactId>
         <version>4.10.6</version>
       </dependency>
       <dependency>
@@ -1700,7 +1675,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-rest-openapi-starter</artifactId>
-        <version>4.10.6</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>

--- a/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomDependenciesGeneratorMojo.java
+++ b/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomDependenciesGeneratorMojo.java
@@ -272,11 +272,6 @@ public class BomDependenciesGeneratorMojo extends AbstractMojo {
         dep.setArtifactId("camel-spring-boot-xml-starter");
         dep.setVersion("${project.version}");
         outDependencies.add(dep);
-        dep = new Dependency();
-        dep.setGroupId("org.apache.camel.springboot");
-        dep.setArtifactId("camel-k-starter");
-        dep.setVersion(productizedArtifacts.containsKey("camel-k-starter") ? "${project.version}" : camelCommunityVersion);
-        outDependencies.add(dep);
 
         // include dsl starters
         dep = new Dependency();
@@ -301,28 +296,8 @@ public class BomDependenciesGeneratorMojo extends AbstractMojo {
         outDependencies.add(dep);
         dep = new Dependency();
         dep.setGroupId("org.apache.camel.springboot");
-        dep.setArtifactId("camel-groovy-dsl-starter");
-        dep.setVersion(productizedArtifacts.containsKey("camel-groovy-dsl-starter") ? "${project.version}" : camelCommunityVersion);
-        outDependencies.add(dep);
-        dep = new Dependency();
-        dep.setGroupId("org.apache.camel.springboot");
         dep.setArtifactId("camel-java-joor-dsl-starter");
         dep.setVersion(productizedArtifacts.containsKey("camel-java-joor-dsl-starter") ? "${project.version}" : camelCommunityVersion);
-        outDependencies.add(dep);
-        dep = new Dependency();
-        dep.setGroupId("org.apache.camel.springboot");
-        dep.setArtifactId("camel-js-dsl-starter");
-        dep.setVersion(productizedArtifacts.containsKey("camel-js-dsl-starter") ? "${project.version}" : camelCommunityVersion);
-        outDependencies.add(dep);
-        dep = new Dependency();
-        dep.setGroupId("org.apache.camel.springboot");
-        dep.setArtifactId("camel-jsh-dsl-starter");
-        dep.setVersion(productizedArtifacts.containsKey("camel-jsh-dsl-starter") ? "${project.version}" : camelCommunityVersion);
-        outDependencies.add(dep);
-        dep = new Dependency();
-        dep.setGroupId("org.apache.camel.springboot");
-        dep.setArtifactId("camel-kotlin-dsl-starter");
-        dep.setVersion(productizedArtifacts.containsKey("camel-kotlin-dsl-starter") ? "${project.version}" : camelCommunityVersion);
         outDependencies.add(dep);
         dep = new Dependency();
         dep.setGroupId("org.apache.camel.springboot");

--- a/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomGeneratorMojo.java
+++ b/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomGeneratorMojo.java
@@ -177,12 +177,7 @@ public class BomGeneratorMojo extends AbstractMojo {
         dep.setArtifactId("camel-spring-boot-xml-starter");
         dep.setVersion(productizedArtifacts.containsKey("camel-spring-boot-xml-starter") ? "${project.version}" : camelCommunityVersion);
         outDependencies.add(dep);
-        dep = new Dependency();
-        dep.setGroupId("org.apache.camel.springboot");
-        dep.setArtifactId("camel-k-starter");
-        dep.setVersion(productizedArtifacts.containsKey("camel-k-starter") ? "${project.version}" : camelCommunityVersion);
-        outDependencies.add(dep);
-
+        
         // include base jars
         dep = new Dependency();
         dep.setGroupId("org.apache.camel.springboot");
@@ -224,33 +219,8 @@ public class BomGeneratorMojo extends AbstractMojo {
         outDependencies.add(dep);
         dep = new Dependency();
         dep.setGroupId("org.apache.camel.springboot");
-        dep.setArtifactId("camel-groovy-dsl-starter");
-        dep.setVersion(productizedArtifacts.containsKey("camel-groovy-dsl-starter") ? "${project.version}" : camelCommunityVersion);
-        outDependencies.add(dep);
-        dep = new Dependency();
-        dep.setGroupId("org.apache.camel.springboot");
         dep.setArtifactId("camel-java-joor-dsl-starter");
         dep.setVersion(productizedArtifacts.containsKey("camel-java-joor-dsl-starter") ? "${project.version}" : camelCommunityVersion);
-        outDependencies.add(dep);
-        dep = new Dependency();
-        dep.setGroupId("org.apache.camel.springboot");
-        dep.setArtifactId("camel-js-dsl-starter");
-        dep.setVersion(productizedArtifacts.containsKey("camel-js-dsl-starter") ? "${project.version}" : camelCommunityVersion);
-        outDependencies.add(dep);
-        dep = new Dependency();
-        dep.setGroupId("org.apache.camel.springboot");
-        dep.setArtifactId("camel-jsh-dsl-starter");
-        dep.setVersion(productizedArtifacts.containsKey("camel-jsh-dsl-starter") ? "${project.version}" : camelCommunityVersion);
-        outDependencies.add(dep);
-        dep = new Dependency();
-        dep.setGroupId("org.apache.camel.springboot");
-        dep.setArtifactId("camel-kotlin-api-starter");
-        dep.setVersion(productizedArtifacts.containsKey("camel-kotlin-api-starter") ? "${project.version}" : camelCommunityVersion);
-        outDependencies.add(dep);
-        dep = new Dependency();
-        dep.setGroupId("org.apache.camel.springboot");
-        dep.setArtifactId("camel-kotlin-dsl-starter");
-        dep.setVersion(productizedArtifacts.containsKey("camel-kotlin-dsl-starter") ? "${project.version}" : camelCommunityVersion);
         outDependencies.add(dep);
         dep = new Dependency();
         dep.setGroupId("org.apache.camel.springboot");

--- a/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomGeneratorMojo.java
+++ b/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomGeneratorMojo.java
@@ -265,7 +265,7 @@ public class BomGeneratorMojo extends AbstractMojo {
         dep = new Dependency();
         dep.setGroupId("org.apache.camel.springboot");
         dep.setArtifactId("camel-yaml-io-starter");
-        dep.setVersion(project.getVersion());
+        dep.setVersion(productizedArtifacts.containsKey("camel-yaml-io-starter") ? "${project.version}" : camelCommunityVersion);
         outDependencies.add(dep);
         dep = new Dependency();
         dep.setGroupId("org.apache.camel.springboot");


### PR DESCRIPTION
This is a cherry pick of a number of commits that went into camel-4.10.3-branch that we need in 4.10.6-branch - there are a few test changes (disables, additions), a few changes to productized starters necessary for MRRC and for supported components, and the removals of a few deprecated starters (camel-k, etc).

