### PR TITLE
Add an override for parquet-avro/parquet-common

### DIFF
--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -209,6 +209,17 @@
                 <artifactId>avro</artifactId>
                 <version>${avro-version}</version>
             </dependency>
+            <!-- Override parquet avro -->
+            <dependency>
+                <groupId>org.apache.parquet</groupId>
+                <artifactId>parquet-avro</artifactId>
+                <version>${parquet-common-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.parquet</groupId>
+                <artifactId>parquet-common</artifactId>
+                <version>${parquet-common-version}</version>
+            </dependency>
             <!-- Override commons-compress version -->
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -209,6 +209,17 @@
                 <artifactId>avro</artifactId>
                 <version>1.12.0</version>
             </dependency>
+            <!-- Override parquet avro -->
+            <dependency>
+                <groupId>org.apache.parquet</groupId>
+                <artifactId>parquet-avro</artifactId>
+                <version>1.15.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.parquet</groupId>
+                <artifactId>parquet-common</artifactId>
+                <version>1.15.0</version>
+            </dependency>
             <!-- Override commons-compress version -->
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
https://github.com/jboss-fuse/camel/pull/2825 upgrades the parquet version in the camel parent/pom.xml, this commit provides a camel-spring-boot BOM override.  

Note : the version in the bom here appears as 1.15.0 but will appear as 1.15.2 in the next build after https://github.com/jboss-fuse/camel/pull/2825 is merged.    