### PR TITLE
CSB-7347 Support camel-springdoc-starter

### DIFF
--- a/.mvn/excludes.txt
+++ b/.mvn/excludes.txt
@@ -186,7 +186,6 @@
 :camel-smpp-starter
 :camel-snakeyaml-starter
 :camel-solr-starter
-:camel-springdoc-starter
 :camel-stax-starter
 :camel-stitch-starter
 :camel-stomp-starter

--- a/components-starter/pom.xml
+++ b/components-starter/pom.xml
@@ -409,7 +409,7 @@
     <module>camel-spring-security-starter</module>
     <module>camel-spring-starter</module>
     <module>camel-spring-ws-starter</module>
-    <!-- <module>camel-springdoc-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
+    <module>camel-springdoc-starter</module>
     <module>camel-sql-starter</module>
     <module>camel-ssh-starter</module>
     <!-- <module>camel-stax-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->

--- a/product/src/main/resources/required-productized-camel-artifacts.txt
+++ b/product/src/main/resources/required-productized-camel-artifacts.txt
@@ -130,6 +130,7 @@ camel-soap-starter
 camel-splunk-starter
 camel-splunk-hec-starter
 camel-spring-starter
+camel-springdoc-starter
 camel-spring-batch-starter
 camel-spring-jdbc-starter
 camel-spring-ldap-starter

--- a/tooling/camel-spring-boot-bom/pom.xml
+++ b/tooling/camel-spring-boot-bom/pom.xml
@@ -1646,7 +1646,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-springdoc-starter</artifactId>
-        <version>4.10.6</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -1880,7 +1880,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-springdoc-starter</artifactId>
-        <version>4.10.6</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/CSB-7347

Usually we don't change supported components for patch releases, but I think this one is different in that it's a CSB-only starter with no related camel component.    