### PR TITLE
Fix ComplexTypesTest (use JSONAssert for ordering)

### DIFF
--- a/components-starter/camel-openapi-java-starter/pom.xml
+++ b/components-starter/camel-openapi-java-starter/pom.xml
@@ -83,6 +83,12 @@
       <artifactId>spring-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <version>${jsonassert-version}</version>
+      <scope>test</scope>
+    </dependency>
     <!--START OF GENERATED CODE-->
     <dependency>
       <groupId>org.apache.camel.springboot</groupId>

--- a/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/ComplexTypesTest.java
+++ b/components-starter/camel-openapi-java-starter/src/test/java/org/apache/camel/openapi/ComplexTypesTest.java
@@ -33,6 +33,9 @@ import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 
 import org.junit.jupiter.api.Test;
 
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -134,7 +137,7 @@ public class ComplexTypesTest {
                 .collect(Collectors.joining("\n"));
         is.close();
 
-        assertEquals(expected, json);
+        JSONAssert.assertEquals(expected, json, JSONCompareMode.STRICT);
     }
 
     private BeanConfig getBeanConfig(String apiVersion) {

--- a/components-starter/camel-openapi-java-starter/src/test/resources/org/apache/camel/openapi/V3SchemaForComplexTypesRequest.json
+++ b/components-starter/camel-openapi-java-starter/src/test/resources/org/apache/camel/openapi/V3SchemaForComplexTypesRequest.json
@@ -9,7 +9,6 @@
         "summary" : "Demo complex request type",
         "operationId" : "verb",
         "requestBody" : {
-          "description" : "",
           "content" : {
             "application/json" : {
               "schema" : {

--- a/components-starter/camel-openapi-java-starter/src/test/resources/org/apache/camel/openapi/V3SchemaForComplexTypesResponse.json
+++ b/components-starter/camel-openapi-java-starter/src/test/resources/org/apache/camel/openapi/V3SchemaForComplexTypesResponse.json
@@ -9,7 +9,6 @@
         "summary" : "Demo complex response type",
         "operationId" : "verb",
         "requestBody" : {
-          "description" : "",
           "content" : {
             "application/json" : {
               "schema" : {


### PR DESCRIPTION
ComplexTypesTest is failing - remove the description fields from the expected responses and add JSONAssert so we compare without order : https://jenkins-csb-fuse-ci.dno.corp.redhat.com/blue/organizations/jenkins/CamelSpringBoot%2Fcamel-spring-boot/detail/PR-564/1/tests/