### PR TITLE
Upgrade third party dependencies to more recent versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     </distributionManagement>
 
     <properties>
-        <aalto-xml-version>1.3.2</aalto-xml-version>
+        <aalto-xml-version>1.3.3</aalto-xml-version>
         <camel-cics.version>4.10.6.redhat-00002</camel-cics.version>
         <camel-community-version>4.10.6</camel-community-version>
         <camel-kamelets-version>4.10.6</camel-kamelets-version>
@@ -109,15 +109,15 @@
         <cq-plugin.version>4.16.2</cq-plugin.version>
         <jakarta-el-version>6.0.1</jakarta-el-version>
         <jakarta-resource-version>2.0.0</jakarta-resource-version>
-        <jna-version>5.13.0</jna-version>
-        <jobjc-version>2.8</jobjc-version>
+        <jna-version>5.17.0</jna-version>
+        <jobjc-version>3.0.0</jobjc-version>
         <kryo-version>2.24.0</kryo-version>
         <narayana-spring-boot.version>3.3.1.redhat-00032</narayana-spring-boot.version>
         <openshift-maven-plugin-version>1.18.1.redhat-00007</openshift-maven-plugin-version>
-        <org-json-json-version>20231013</org-json-json-version>
-        <parsson-version>1.0.5</parsson-version>
+        <org-json-json-version>20250517</org-json-json-version>
+        <parsson-version>1.1.7</parsson-version>
         <perfmark-version>0.27.0</perfmark-version>
-        <snappy-java-version>1.1.10.7</snappy-java-version>
+        <snappy-java-version>1.1.10.8</snappy-java-version>
         <tomcat-version>10.1.44</tomcat-version>
         <woodstox-stax2-api-version>4.2.1</woodstox-stax2-api-version>
 


### PR DESCRIPTION
There are a number of dependencies we define in our BOM that have newer versions - updating the versions for the BOM