### PR TITLE
Cherry pick of two BOM commits from 4.10.6; refresh

### DIFF
--- a/tooling/camel-spring-boot-bom/pom.xml
+++ b/tooling/camel-spring-boot-bom/pom.xml
@@ -760,11 +760,6 @@
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>camel-groovy-dsl-starter</artifactId>
-        <version>4.14.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-groovy-starter</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -1030,17 +1025,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>camel-js-dsl-starter</artifactId>
-        <version>4.14.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-jsch-starter</artifactId>
-        <version>4.14.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>camel-jsh-dsl-starter</artifactId>
         <version>4.14.0</version>
       </dependency>
       <dependency>
@@ -1090,11 +1075,6 @@
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>camel-k-starter</artifactId>
-        <version>4.14.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-kafka-starter</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -1106,16 +1086,6 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-knative-starter</artifactId>
-        <version>4.14.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>camel-kotlin-api-starter</artifactId>
-        <version>4.14.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
-        <artifactId>camel-kotlin-dsl-starter</artifactId>
         <version>4.14.0</version>
       </dependency>
       <dependency>
@@ -1971,7 +1941,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-yaml-io-starter</artifactId>
-        <version>4.14.0-SNAPSHOT</version>
+        <version>4.14.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -290,7 +290,7 @@
       <dependency>
         <groupId>org.apache.camel.kamelets</groupId>
         <artifactId>camel-kamelets-bom</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00004</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.maven</groupId>

--- a/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomGeneratorMojo.java
+++ b/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomGeneratorMojo.java
@@ -177,12 +177,7 @@ public class BomGeneratorMojo extends AbstractMojo {
         dep.setArtifactId("camel-spring-boot-xml-starter");
         dep.setVersion(productizedArtifacts.containsKey("camel-spring-boot-xml-starter") ? "${project.version}" : camelCommunityVersion);
         outDependencies.add(dep);
-        dep = new Dependency();
-        dep.setGroupId("org.apache.camel.springboot");
-        dep.setArtifactId("camel-k-starter");
-        dep.setVersion(productizedArtifacts.containsKey("camel-k-starter") ? "${project.version}" : camelCommunityVersion);
-        outDependencies.add(dep);
-
+        
         // include base jars
         dep = new Dependency();
         dep.setGroupId("org.apache.camel.springboot");
@@ -224,33 +219,8 @@ public class BomGeneratorMojo extends AbstractMojo {
         outDependencies.add(dep);
         dep = new Dependency();
         dep.setGroupId("org.apache.camel.springboot");
-        dep.setArtifactId("camel-groovy-dsl-starter");
-        dep.setVersion(productizedArtifacts.containsKey("camel-groovy-dsl-starter") ? "${project.version}" : camelCommunityVersion);
-        outDependencies.add(dep);
-        dep = new Dependency();
-        dep.setGroupId("org.apache.camel.springboot");
         dep.setArtifactId("camel-java-joor-dsl-starter");
         dep.setVersion(productizedArtifacts.containsKey("camel-java-joor-dsl-starter") ? "${project.version}" : camelCommunityVersion);
-        outDependencies.add(dep);
-        dep = new Dependency();
-        dep.setGroupId("org.apache.camel.springboot");
-        dep.setArtifactId("camel-js-dsl-starter");
-        dep.setVersion(productizedArtifacts.containsKey("camel-js-dsl-starter") ? "${project.version}" : camelCommunityVersion);
-        outDependencies.add(dep);
-        dep = new Dependency();
-        dep.setGroupId("org.apache.camel.springboot");
-        dep.setArtifactId("camel-jsh-dsl-starter");
-        dep.setVersion(productizedArtifacts.containsKey("camel-jsh-dsl-starter") ? "${project.version}" : camelCommunityVersion);
-        outDependencies.add(dep);
-        dep = new Dependency();
-        dep.setGroupId("org.apache.camel.springboot");
-        dep.setArtifactId("camel-kotlin-api-starter");
-        dep.setVersion(productizedArtifacts.containsKey("camel-kotlin-api-starter") ? "${project.version}" : camelCommunityVersion);
-        outDependencies.add(dep);
-        dep = new Dependency();
-        dep.setGroupId("org.apache.camel.springboot");
-        dep.setArtifactId("camel-kotlin-dsl-starter");
-        dep.setVersion(productizedArtifacts.containsKey("camel-kotlin-dsl-starter") ? "${project.version}" : camelCommunityVersion);
         outDependencies.add(dep);
         dep = new Dependency();
         dep.setGroupId("org.apache.camel.springboot");

--- a/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomGeneratorMojo.java
+++ b/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomGeneratorMojo.java
@@ -265,7 +265,7 @@ public class BomGeneratorMojo extends AbstractMojo {
         dep = new Dependency();
         dep.setGroupId("org.apache.camel.springboot");
         dep.setArtifactId("camel-yaml-io-starter");
-        dep.setVersion(project.getVersion());
+        dep.setVersion(productizedArtifacts.containsKey("camel-yaml-io-starter") ? "${project.version}" : camelCommunityVersion);
         outDependencies.add(dep);
         dep = new Dependency();
         dep.setGroupId("org.apache.camel.springboot");


### PR DESCRIPTION
Marete test failure : 

https://jenkins-csb-fuse-qe-fuse-next.dno.corp.redhat.com/view/Camel%20Spring%20Boot/job/camel-springboot/job/rhaf-csb-4.14.x/job/marete/3/testReport/org.jboss.qa.marete/AdditionalChecksMavenRepoTest/runAdditionalChecks/

`Directory for artifact org.apache.camel.springboot:camel-yaml-io-starter:4.14.0.redhat-00010 (defined in BOM Bom{coordinates=org.apache.camel.springboot:camel-spring-boot-bom:4.14.0.redhat-00010, skipArtifacts=[], checkContent=true}) must exist in /home/hudson/mrrc/rhaf-camel-spring-boot-4.14.0.CS1-maven-repository/maven-repository/org/apache/camel/springboot/camel-yaml-io-starter/4.14.0.redhat-00010
`

The fix to this is https://github.com/jboss-fuse/camel-spring-boot/commit/e5c5b8299f3e3c7e3f95e9f777a2a0cede6f71b5 - we need to cherry-pick this over to 4.14.     Also noticed we need https://github.com/jboss-fuse/camel-spring-boot/commit/9913346539f0fcd65ca177605f1946f67c1440e8 so cherry-picked that as well, added them to the patching tool so they are covered next time we take a new branch.     Then did a mvn -DskipTests clean install and the BOM and the dependecies refreshed.