### PR TITLE
CSB-7805 Productize camel-debug-starter

### DIFF
--- a/.mvn/excludes.txt
+++ b/.mvn/excludes.txt
@@ -28,6 +28,7 @@
 :camel-aws2-translate-starter
 :camel-azure-cosmosdb-starter
 :camel-azure-files-starter
+:camel-azure-storage-datalake-starter
 :camel-barcode-starter
 :camel-base64-starter
 :camel-bonita-starter
@@ -58,7 +59,6 @@
 :camel-debezium-oracle-starter
 :camel-debezium-postgres-starter
 :camel-debezium-sqlserver-starter
-:camel-debug-starter
 :camel-dfdl-starter
 :camel-dhis2-starter
 :camel-digitalocean-starter
@@ -224,6 +224,7 @@
 :camel-xml-jaxb-dsl-starter
 :camel-xmlsecurity-starter
 :camel-xmpp-starter
+:camel-yaml-io-starter
 :camel-zeebe-starter
 :camel-zendesk-starter
 :camel-zip-deflater-starter

--- a/components-starter/camel-debug-starter/src/main/docs/debug.json
+++ b/components-starter/camel-debug-starter/src/main/docs/debug.json
@@ -25,8 +25,7 @@
       "name": "camel.debug.body-max-chars",
       "type": "java.lang.Integer",
       "description": "To limit the message body to a maximum size in the traced message. Use 0 or negative value to use unlimited size.",
-      "sourceType": "org.apache.camel.spring.boot.debug.CamelDebugConfigurationProperties",
-      "defaultValue": 0
+      "sourceType": "org.apache.camel.spring.boot.debug.CamelDebugConfigurationProperties"
     },
     {
       "name": "camel.debug.breakpoints",

--- a/components-starter/pom.xml
+++ b/components-starter/pom.xml
@@ -195,7 +195,7 @@
     <!-- <module>camel-debezium-oracle-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-debezium-postgres-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-debezium-sqlserver-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
-    <!-- <module>camel-debug-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
+    <module>camel-debug-starter</module>
     <!-- <module>camel-dfdl-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-dhis2-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-digitalocean-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->

--- a/maintenance/pom.xml
+++ b/maintenance/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>spring-boot-parent</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.14.0-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/maintenance/redhat-camel-spring-boot-patch-metadata/pom.xml
+++ b/maintenance/redhat-camel-spring-boot-patch-metadata/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.redhat.camel.springboot.platform</groupId>
         <artifactId>redhat-camel-spring-boot-maintenance</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.14.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>redhat-camel-spring-boot-patch-metadata</artifactId>

--- a/maintenance/redhat-camel-spring-boot-patch-repository/pom.xml
+++ b/maintenance/redhat-camel-spring-boot-patch-repository/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.redhat.camel.springboot.platform</groupId>
         <artifactId>redhat-camel-spring-boot-maintenance</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.14.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>redhat-camel-spring-boot-patch-repository</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dependencies</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
     </parent>
 
     <groupId>org.apache.camel.springboot</groupId>
@@ -134,7 +134,7 @@
         <spring-boot-version>3.5.5</spring-boot-version>
 
         <!-- Camel target version -->
-        <camel-version>4.14.0.redhat-00003</camel-version>
+        <camel-version>4.14.0.redhat-00006</camel-version>
 
         <!-- versions -->
         <aether-version>1.0.2.v20150114</aether-version>

--- a/product/src/main/resources/required-productized-camel-artifacts.txt
+++ b/product/src/main/resources/required-productized-camel-artifacts.txt
@@ -45,6 +45,7 @@ camel-cxf-soap-starter
 camel-cxf-transport-starter
 camel-dataformat-starter
 camel-dataset-starter
+camel-debug-starter
 camel-direct-starter
 camel-elasticsearch-starter
 camel-elasticsearch-rest-client-starter

--- a/tooling/camel-spring-boot-bom/pom.xml
+++ b/tooling/camel-spring-boot-bom/pom.xml
@@ -531,7 +531,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-debug-starter</artifactId>
-        <version>4.14.0</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -295,17 +295,17 @@
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-debezium-maven-plugin</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-salesforce-maven-plugin</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-servicenow-maven-plugin</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -775,7 +775,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-debug-starter</artifactId>
-        <version>4.14.0</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -2235,7 +2235,7 @@
       <dependency>
         <groupId>org.apache.camel.tests</groupId>
         <artifactId>org.apache.camel.tests.mock-javamail_1.7</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2250,18 +2250,18 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-allcomponents</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-amqp</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-api</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2301,12 +2301,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-attachments</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-avro</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2341,7 +2341,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-secrets-manager</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2356,12 +2356,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-cw</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ddb</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2391,7 +2391,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-kinesis</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2401,7 +2401,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-lambda</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2421,7 +2421,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-s3</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2431,12 +2431,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sns</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sqs</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2466,7 +2466,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-eventhubs</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2476,7 +2476,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-key-vault</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2486,22 +2486,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-servicebus</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-blob</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-datalake</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-queue</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2511,12 +2511,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base-engine</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2526,22 +2526,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean-validator</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-beanio</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bindy</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2566,7 +2566,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-browse</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2576,17 +2576,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cassandraql</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog-console</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2601,7 +2601,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog-suggest</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2621,7 +2621,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cli-connector</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2631,17 +2631,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloud</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloudevents</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cluster</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2661,12 +2661,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-componentdsl</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-console</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2676,12 +2676,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-controlbus</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2692,37 +2692,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-catalog</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-engine</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-languages</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-model</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-processor</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-reifier</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-xml</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2737,17 +2737,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cron</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-crypto</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-crypto-pgp</artifactId>
-        <version>4.14.0</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2767,42 +2767,42 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-common</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-rest</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-soap</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-common</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-rest</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-soap</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-transport</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-transport</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2812,12 +2812,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataformat</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataset</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2862,7 +2862,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debug</artifactId>
-        <version>4.14.0</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2887,7 +2887,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-direct</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2922,12 +2922,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-modeline</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-support</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2942,12 +2942,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch-rest-client</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2957,12 +2957,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl-support</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2977,17 +2977,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir-api</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-file</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3002,7 +3002,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-flink</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3027,7 +3027,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ftp</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3047,7 +3047,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-bigquery</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3072,7 +3072,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-pubsub</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3082,7 +3082,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-secret-manager</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3102,7 +3102,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-graphql</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3112,17 +3112,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-groovy</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-grpc</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-gson</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3132,7 +3132,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hashicorp-vault</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3147,27 +3147,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-health</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hl7</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-base</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-common</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3232,17 +3232,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-common</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-embedded</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3272,22 +3272,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-avro</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-protobuf</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jacksonxml</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3297,12 +3297,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jasypt</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-java-joor-dsl</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3312,32 +3312,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jaxb</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbang-console</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbang-core</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbang-main</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbang-plugin-generate</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbang-plugin-kubernetes</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3357,7 +3357,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jdbc</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3372,7 +3372,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jfr</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3387,12 +3387,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jira</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jms</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3412,17 +3412,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-joor</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jpa</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jq</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3432,7 +3432,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jslt</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3462,17 +3462,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonpath</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jt400</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jta</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3482,32 +3482,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kafka</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet-main</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-api</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-http</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3517,12 +3517,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kubernetes</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kudu</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3567,12 +3567,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-language</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ldap</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3587,12 +3587,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-log</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lra</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3612,37 +3612,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail-microsoft-oauth</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-main</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management-api</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mapstruct</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-master</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3652,27 +3652,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-micrometer</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-micrometer-prometheus</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-config</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-fault-tolerance</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-health</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3687,22 +3687,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-minio</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mllp</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mock</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mongodb</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3722,12 +3722,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mybatis</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nats</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3737,12 +3737,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty-http</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3762,7 +3762,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-observability-services</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3787,22 +3787,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4-api</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-java</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-rest-dsl-generator</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3812,7 +3812,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opensearch</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3822,12 +3822,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opentelemetry</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opentelemetry2</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3837,12 +3837,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho-mqtt5</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3872,7 +3872,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3882,12 +3882,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-main</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-vertx</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3932,7 +3932,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-quartz</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3967,7 +3967,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ref</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3977,22 +3977,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-resilience4j</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-resourceresolver-github</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest-openapi</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4022,12 +4022,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saga</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-salesforce</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4042,12 +4042,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saxon</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-scheduler</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4057,7 +4057,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-seda</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4072,7 +4072,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-servlet</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4092,17 +4092,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-slack</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smb</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smooks</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4117,12 +4117,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-snmp</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-soap</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4132,22 +4132,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk-hec</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-batch</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4157,52 +4157,52 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-jdbc</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-ldap</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-main</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-rabbitmq</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-redis</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-security</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-ws</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-xml</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sql</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ssh</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4232,12 +4232,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stub</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-support</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4262,12 +4262,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-telegram</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-telemetry</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4282,12 +4282,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-junit5</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4297,7 +4297,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-spring-junit5</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4322,22 +4322,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-timer</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-maven</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-model</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-util</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4347,7 +4347,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tracing</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4362,12 +4362,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-undertow</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-undertow-spring-security</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4377,22 +4377,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util-json</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-validator</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-velocity</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4402,17 +4402,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-common</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-http</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-websocket</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4442,7 +4442,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-webhook</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4467,27 +4467,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xj</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-dsl</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-util</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxb</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4497,12 +4497,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp-util</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4517,37 +4517,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xpath</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt-saxon</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-common</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-deserializers</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-io</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4562,12 +4562,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zip-deflater</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zipfile</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4587,12 +4587,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>spi-annotations</artifactId>
-        <version>4.14.0.redhat-00003</version>
+        <version>4.14.0.redhat-00006</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
         <artifactId>maven-plugin-annotations</artifactId>
-        <version>3.15.1</version>
+        <version>3.15.1.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugins</groupId>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -74,12 +74,12 @@
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-api</artifactId>
-                <version>4.14.0.redhat-00003</version>
+                <version>4.14.0.redhat-00006</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-support</artifactId>
-                <version>4.14.0.redhat-00003</version>
+                <version>4.14.0.redhat-00006</version>
             </dependency>
 
             <!-- Insert third party overrides here -->
@@ -159,13 +159,13 @@
             <dependency>
                 <groupId>org.mvel</groupId>
                 <artifactId>mvel2</artifactId>
-                <version>2.5.2.Final-redhat-00001</version>
+                <version>2.5.2.Final-redhat-00002</version>
             </dependency>
             <!-- Overrides json-path dependency -->
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path</artifactId>
-                <version>2.9.0.redhat-00001</version>
+                <version>2.9.0.redhat-00002</version>
             </dependency>
             <!-- Overrides avro dependency version since SB's jackson version's takes precedence in camel-jackson-avro-starter -->
             <dependency>
@@ -240,7 +240,7 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-bom</artifactId>
-                <version>12.0.25.redhat-00001</version>
+                <version>12.0.25.redhat-00002</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -282,7 +282,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.19.2.redhat-00001</version>
+                <version>2.19.2.redhat-00003</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -290,7 +290,7 @@
             <dependency>
                 <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-bom</artifactId>
-                <version>15.2.5.Final</version>
+                <version>15.0.19.Final-redhat-00001</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -314,7 +314,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.20.0.redhat-00001</version>
+                <version>2.20.0.redhat-00002</version>
             </dependency>
 
             <dependency>
@@ -338,13 +338,13 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.14.redhat-00012</version>
+                <version>4.5.14.redhat-00016</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient-cache</artifactId>
-                <version>4.5.14.redhat-00012</version>
+                <version>4.5.14.redhat-00016</version>
             </dependency>
 
             <dependency>
@@ -380,7 +380,7 @@
             <dependency>
                 <groupId>jakarta.inject</groupId>
                 <artifactId>jakarta.inject</artifactId>
-                <version>2.0.1.redhat-00006</version>
+                <version>2.0.1.redhat-00007</version>
             </dependency>
 
             <dependency>
@@ -392,13 +392,13 @@
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.14.0</version>
+                <version>2.14.0.redhat-00001</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
-                <version>1.14.0.redhat-00001</version>
+                <version>1.14.0.redhat-00002</version>
             </dependency>
 
             <dependency>
@@ -448,43 +448,43 @@
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
-                <version>9.8</version>
+                <version>9.8.0.redhat-00002</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-commons</artifactId>
-                <version>9.8</version>
+                <version>9.8.0.redhat-00002</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-tree</artifactId>
-                <version>9.8</version>
+                <version>9.8.0.redhat-00002</version>
             </dependency>
 
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>
                 <artifactId>swagger-integration-jakarta</artifactId>
-                <version>2.2.32</version>
+                <version>2.2.32.redhat-00001</version>
             </dependency>
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>
                 <artifactId>swagger-jaxrs2-jakarta</artifactId>
-                <version>2.2.32</version>
+                <version>2.2.32.redhat-00001</version>
             </dependency>
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>
                 <artifactId>swagger-models</artifactId>
-                <version>2.2.32</version>
+                <version>2.2.32.redhat-00001</version>
             </dependency>
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>
                 <artifactId>swagger-models-jakarta</artifactId>
-                <version>2.2.32</version>
+                <version>2.2.32.redhat-00001</version>
             </dependency>
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>
                 <artifactId>swagger-core-jakarta</artifactId>
-                <version>2.2.32</version>
+                <version>2.2.32.redhat-00001</version>
             </dependency>
 
             <dependency>
@@ -510,7 +510,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-bom</artifactId>
-                <version>4.1.3.rhbac-redhat-00004</version>
+                <version>4.1.3.rhbac-redhat-00007</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/CSB-7805

Upgraded the camel version to 4.14.0.redhat-00006 (version of camel with a productized camel-debug component) and productize camel-debug-starter.