### PR TITLE
Replaces deprecated camel.springboot.name property

### DIFF
--- a/archetypes/camel-archetype-spring-boot/src/main/resources/archetype-resources/src/main/resources/application.properties
+++ b/archetypes/camel-archetype-spring-boot/src/main/resources/archetype-resources/src/main/resources/application.properties
@@ -16,7 +16,7 @@
 ## ---------------------------------------------------------------------------
 
 # the name of Camel
-camel.springboot.name = MyCamel
+camel.main.name = MyCamel
 
 # what to say
 greeting = Hello World

--- a/core/camel-spring-boot-xml/src/test/java/org/apache/camel/spring/boot/xml/MixedBootAndXmlConfigurationTest.java
+++ b/core/camel-spring-boot-xml/src/test/java/org/apache/camel/spring/boot/xml/MixedBootAndXmlConfigurationTest.java
@@ -29,7 +29,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @DirtiesContext
 @CamelSpringBootTest
-@SpringBootTest(properties = { "camel.springboot.name = camel-spring-boot", "camel.springboot.tracing = true",
+@SpringBootTest(properties = { "camel.main.name = camel-spring-boot", "camel.springboot.tracing = true",
         "camel.springboot.shutdownTimeout = 5" })
 public class MixedBootAndXmlConfigurationTest {
 

--- a/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/CamelAutoConfigurationTest.java
+++ b/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/CamelAutoConfigurationTest.java
@@ -48,7 +48,7 @@ import org.springframework.test.annotation.DirtiesContext;
 @EnableAutoConfiguration
 @SpringBootTest(classes = { CamelAutoConfigurationTest.TestConfig.class, CamelAutoConfigurationTest.class,
         RouteConfigWithCamelContextInjected.class }, properties = { "camel.springboot.consumerTemplateCacheSize=100",
-                "camel.springboot.jmxEnabled=true", "camel.springboot.name=customName",
+                "camel.springboot.jmxEnabled=true", "camel.main.name=customName",
                 "camel.springboot.typeConversion=true",
                 "camel.springboot.threadNamePattern=customThreadName #counter#" })
 public class CamelAutoConfigurationTest extends org.junit.jupiter.api.Assertions {

--- a/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/CamelAutoConfigurationWithCompatPrefixTest.java
+++ b/core/camel-spring-boot/src/test/java/org/apache/camel/spring/boot/CamelAutoConfigurationWithCompatPrefixTest.java
@@ -34,7 +34,7 @@ import org.springframework.test.annotation.DirtiesContext;
 @DirtiesContext
 @CamelSpringBootTest
 @EnableAutoConfiguration
-@SpringBootTest(properties = { "camel.springboot.consumerTemplateCacheSize=100", "camel.springboot.name=customName" })
+@SpringBootTest(properties = { "camel.springboot.consumerTemplateCacheSize=100", "camel.main.name=customName" })
 public class CamelAutoConfigurationWithCompatPrefixTest {
 
     // Collaborators fixtures


### PR DESCRIPTION
cherry pick f667ad3aa3cfeeab29a71a37fcf39cbd70570394 from 4.10.6