### PR TITLE
Add dependencyManagement entry for parsson so it can be aligned to productized version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <narayana-spring-boot.version>3.3.1.redhat-00037</narayana-spring-boot.version>
         <openshift-maven-plugin-version>1.18.1.redhat-00007</openshift-maven-plugin-version>
         <org-json-json-version>20250517</org-json-json-version>
-        <parsson-version>1.1.7</parsson-version>
+        <parsson-version>1.1.7.redhat-00003</parsson-version>
         <perfmark-version>0.27.0</perfmark-version>
         <plexus-component-metadata-plugin-version>2.1.1</plexus-component-metadata-plugin-version>
         <snappy-java-version>1.1.10.8</snappy-java-version>
@@ -183,6 +183,11 @@
         <groupId>io.perfmark</groupId>
         <artifactId>perfmark-api</artifactId>
         <version>${perfmark-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.parsson</groupId>
+        <artifactId>parsson</artifactId>
+        <version>${parsson-version}</version>
       </dependency>
       <dependency>
         <groupId>io.projectreactor.netty</groupId>

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -4626,6 +4626,11 @@
         <version>1.18.1.redhat-00007</version>
       </dependency>
       <dependency>
+        <groupId>org.eclipse.parsson</groupId>
+        <artifactId>parsson</artifactId>
+        <version>1.1.7.redhat-00003</version>
+      </dependency>
+      <dependency>
         <groupId>org.fusesource</groupId>
         <artifactId>camel-cics</artifactId>
         <version>4.10.7.redhat-00001</version>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -252,7 +252,7 @@
             <dependency>
                 <groupId>org.eclipse.parsson</groupId>
                 <artifactId>parsson</artifactId>
-                <version>1.1.7</version>
+                <version>1.1.7.redhat-00003</version>
             </dependency>
 
             <!-- Add overrides for httpclient5 -->


### PR DESCRIPTION
From discussion on bom diffs on call today : 
Add dependencyManagement entry for parsson so it can be aligned to productized version