### PR TITLE
Add a dependencyManagement entry for parsson so it gets aligned

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,11 @@
         <version>${narayana-spring-boot.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.eclipse.parsson</groupId>
+        <artifactId>parsson</artifactId>
+        <version>${parsson-version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.perfmark</groupId>
         <artifactId>perfmark-api</artifactId>
         <version>${perfmark-version}</version>

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -4756,6 +4756,11 @@
         <version>1.18.1.redhat-00007</version>
       </dependency>
       <dependency>
+        <groupId>org.eclipse.parsson</groupId>
+        <artifactId>parsson</artifactId>
+        <version>1.1.7</version>
+      </dependency>
+      <dependency>
         <groupId>org.fusesource</groupId>
         <artifactId>camel-cics</artifactId>
         <version>4.14.1.redhat-00001</version>


### PR DESCRIPTION
For 4.14.1 branch : add a dependencyManagement entry for parsson so it gets aligned by PME