### PR TITLE
Productize camel-azure-storage-datalake-starter

### DIFF
--- a/.mvn/excludes.txt
+++ b/.mvn/excludes.txt
@@ -28,7 +28,6 @@
 :camel-aws2-translate-starter
 :camel-azure-cosmosdb-starter
 :camel-azure-files-starter
-:camel-azure-storage-datalake-starter
 :camel-barcode-starter
 :camel-base64-starter
 :camel-bonita-starter
@@ -231,5 +230,10 @@
 :camel-zookeeper-cluster-service-starter
 :camel-zookeeper-master-starter
 :camel-zookeeper-starter
+:dependency-management-example
+:dependency-management-example-module1
 :docs
+:redhat-camel-spring-boot-maintenance
+:redhat-camel-spring-boot-patch-metadata
+:redhat-camel-spring-boot-patch-repository
 :tests

--- a/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/Utils.java
+++ b/components-starter/camel-jira-starter/src/test/java/org/apache/camel/component/jira/springboot/test/Utils.java
@@ -66,6 +66,15 @@ public final class Utils {
         return createIssueWithComments(id, 0);
     }
 
+    public static Issue createIssueWithCreationDate(long id, DateTime dateTime) {
+        URI selfUri = URI.create(TEST_JIRA_URL + "/rest/api/latest/issue/" + id);
+        return new Issue(
+                "jira summary test " + id, selfUri, KEY + "-" + id, id, null, issueType, null, "Description " + id,
+                null, null, null, null, userAssignee, dateTime, null, null, null, null, null, null, null, null, null,
+                null,
+                null, null, null, null, null, null, null, null, null);
+    }
+
     public static Issue createIssue(long id, String summary, String key, IssueType issueType, String description,
             BasicPriority priority, User assignee, Collection<BasicComponent> components, BasicWatchers watchers) {
         URI selfUri = URI.create(TEST_JIRA_URL + "/rest/api/latest/issue/" + id);

--- a/components-starter/camel-kamelet-starter/src/test/java/org/apache/camel/component/kamelet/springboot/KameletGlobalPropertiesTest.java
+++ b/components-starter/camel-kamelet-starter/src/test/java/org/apache/camel/component/kamelet/springboot/KameletGlobalPropertiesTest.java
@@ -43,7 +43,6 @@ import java.util.Properties;
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @CamelSpringBootTest
 @SpringBootTest(classes = { CamelAutoConfiguration.class, KameletGlobalPropertiesTest.class })
-
 public class KameletGlobalPropertiesTest {
 
     @Autowired
@@ -58,8 +57,12 @@ public class KameletGlobalPropertiesTest {
     // **********************************************
     @UseOverridePropertiesWithPropertiesComponent
     public static Properties useOverridePropertiesWithPropertiesComponent() {
-        return asProperties("proxy.usr", "u+sr", "proxy.pwd", "p+wd", "raw.proxy.usr", "RAW(u+sr)", "raw.proxy.pwd",
-                "RAW(p+wd)", "bodyValue", "from-uri", Kamelet.PROPERTIES_PREFIX + "setBody.bodyValue", "from-template",
+        return asProperties("proxy.usr", "u+sr",
+                "proxy.pwd", "p+wd",
+                "raw.proxy.usr", "RAW(u+sr)",
+                "raw.proxy.pwd", "RAW(p+wd)",
+                "bodyValue", "from-uri",
+                Kamelet.PROPERTIES_PREFIX + "setBody.bodyValue", "from-template",
                 Kamelet.PROPERTIES_PREFIX + "setBody.test.bodyValue", "from-route",
                 Kamelet.PROPERTIES_PREFIX + "setBody.someId.bodyValue", "from-route-someId");
     }
@@ -134,11 +137,11 @@ public class KameletGlobalPropertiesTest {
 
     @Test
     public void urlEncodingIsRespected() {
-        assertThat(context.getEndpoint("kamelet:timer-source?message=Hello+Kamelets&period=1000", KameletEndpoint.class)
+        assertThat(context.getEndpoint("kamelet:timer-source?message=Hello Kamelets&period=1000", KameletEndpoint.class)
                 .getKameletProperties()).containsEntry("message", "Hello Kamelets");
-        assertThat(context.getEndpoint("kamelet:timer-source?message=Hi%20Kamelets&period=1000", KameletEndpoint.class)
+        assertThat(context.getEndpoint("kamelet:timer-source?message=Hi Kamelets&period=1000", KameletEndpoint.class)
                 .getKameletProperties()).containsEntry("message", "Hi Kamelets");
-        assertThat(context.getEndpoint("kamelet:timer-source?message=messaging.knative.dev%2Fv1beta1&period=1000",
+        assertThat(context.getEndpoint("kamelet:timer-source?message=messaging.knative.dev/v1beta1&period=1000",
                 KameletEndpoint.class).getKameletProperties()).containsEntry("message",
                         "messaging.knative.dev/v1beta1");
     }

--- a/components-starter/pom.xml
+++ b/components-starter/pom.xml
@@ -148,7 +148,7 @@
     <module>camel-azure-key-vault-starter</module>
     <module>camel-azure-servicebus-starter</module>
     <module>camel-azure-storage-blob-starter</module>
-    <!-- <module>camel-azure-storage-datalake-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
+    <module>camel-azure-storage-datalake-starter</module>
     <module>camel-azure-storage-queue-starter</module>
     <!-- <module>camel-barcode-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->
     <!-- <module>camel-base64-starter</module> disabled by camel-spring-boot-prod-maven-plugin:camel-prod-excludes -->

--- a/maintenance/pom.xml
+++ b/maintenance/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>spring-boot-parent</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.14.1-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/maintenance/redhat-camel-spring-boot-patch-metadata/pom.xml
+++ b/maintenance/redhat-camel-spring-boot-patch-metadata/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.redhat.camel.springboot.platform</groupId>
         <artifactId>redhat-camel-spring-boot-maintenance</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.14.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>redhat-camel-spring-boot-patch-metadata</artifactId>

--- a/maintenance/redhat-camel-spring-boot-patch-repository/pom.xml
+++ b/maintenance/redhat-camel-spring-boot-patch-repository/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.redhat.camel.springboot.platform</groupId>
         <artifactId>redhat-camel-spring-boot-maintenance</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.14.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>redhat-camel-spring-boot-patch-repository</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dependencies</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
     </parent>
 
     <groupId>org.apache.camel.springboot</groupId>
@@ -134,7 +134,7 @@
         <spring-boot-version>3.5.7</spring-boot-version>
 
         <!-- Camel target version -->
-        <camel-version>4.14.1.redhat-00005</camel-version>
+        <camel-version>4.14.1.redhat-00008</camel-version>
 
         <!-- versions -->
         <aether-version>1.0.2.v20150114</aether-version>

--- a/product/src/main/resources/required-productized-camel-artifacts.txt
+++ b/product/src/main/resources/required-productized-camel-artifacts.txt
@@ -27,6 +27,7 @@ camel-azure-key-vault-starter
 camel-azure-servicebus-starter
 camel-azure-storage-blob-starter
 camel-azure-storage-queue-starter
+camel-azure-storage-datalake-starter
 camel-bean-starter
 camel-beanio-starter
 camel-bean-validator-starter

--- a/tooling/camel-spring-boot-bom/pom.xml
+++ b/tooling/camel-spring-boot-bom/pom.xml
@@ -286,7 +286,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-azure-storage-datalake-starter</artifactId>
-        <version>4.14.1</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -295,17 +295,17 @@
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-debezium-maven-plugin</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-salesforce-maven-plugin</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-servicenow-maven-plugin</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -530,7 +530,7 @@
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-azure-storage-datalake-starter</artifactId>
-        <version>4.14.1</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -2235,7 +2235,7 @@
       <dependency>
         <groupId>org.apache.camel.tests</groupId>
         <artifactId>org.apache.camel.tests.mock-javamail_1.7</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2250,18 +2250,18 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-allcomponents</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-amqp</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-api</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2301,12 +2301,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-attachments</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-avro</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2341,7 +2341,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-secrets-manager</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2356,12 +2356,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-cw</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ddb</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2391,7 +2391,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-kinesis</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2401,7 +2401,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-lambda</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2421,7 +2421,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-s3</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2431,12 +2431,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sns</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sqs</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2466,7 +2466,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-eventhubs</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2476,7 +2476,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-key-vault</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2486,22 +2486,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-servicebus</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-blob</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-datalake</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-queue</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2511,12 +2511,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base-engine</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2526,22 +2526,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean-validator</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-beanio</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bindy</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2566,7 +2566,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-browse</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2576,17 +2576,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cassandraql</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog-console</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2601,7 +2601,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog-suggest</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2621,7 +2621,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cli-connector</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2631,17 +2631,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloud</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloudevents</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cluster</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2661,12 +2661,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-componentdsl</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-console</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2676,12 +2676,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-controlbus</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2692,37 +2692,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-catalog</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-engine</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-languages</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-model</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-processor</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-reifier</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-xml</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2737,17 +2737,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cron</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-crypto</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-crypto-pgp</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2767,42 +2767,42 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-common</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-rest</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-soap</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-common</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-rest</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-soap</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-transport</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-transport</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2812,12 +2812,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataformat</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataset</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2862,7 +2862,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debug</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2887,7 +2887,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-direct</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2922,12 +2922,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-modeline</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-support</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2942,12 +2942,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch-rest-client</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2957,12 +2957,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl-support</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2977,17 +2977,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir-api</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-file</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3002,7 +3002,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-flink</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3027,7 +3027,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ftp</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3047,7 +3047,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-bigquery</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3072,7 +3072,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-pubsub</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3082,7 +3082,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-secret-manager</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3102,7 +3102,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-graphql</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3112,17 +3112,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-groovy</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-grpc</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-gson</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3132,7 +3132,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hashicorp-vault</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3147,27 +3147,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-health</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hl7</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-base</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-common</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3232,17 +3232,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-common</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-embedded</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3272,22 +3272,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-avro</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-protobuf</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jacksonxml</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3297,12 +3297,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jasypt</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-java-joor-dsl</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3312,32 +3312,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jaxb</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbang-console</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbang-core</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbang-main</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbang-plugin-generate</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbang-plugin-kubernetes</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3357,7 +3357,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jdbc</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3372,7 +3372,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jfr</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3387,12 +3387,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jira</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jms</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3412,17 +3412,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-joor</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jpa</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jq</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3432,7 +3432,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jslt</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3462,17 +3462,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonpath</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jt400</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jta</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3482,32 +3482,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kafka</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet-main</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-api</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-http</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3517,12 +3517,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kubernetes</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kudu</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3567,12 +3567,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-language</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ldap</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3587,12 +3587,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-log</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lra</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3612,37 +3612,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail-microsoft-oauth</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-main</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management-api</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mapstruct</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-master</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3652,27 +3652,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-micrometer</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-micrometer-prometheus</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-config</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-fault-tolerance</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-health</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3687,22 +3687,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-minio</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mllp</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mock</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mongodb</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3722,12 +3722,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mybatis</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nats</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3737,12 +3737,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty-http</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3762,7 +3762,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-observability-services</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3787,22 +3787,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4-api</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-java</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-rest-dsl-generator</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3812,7 +3812,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opensearch</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3822,12 +3822,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opentelemetry</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opentelemetry2</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3837,12 +3837,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho-mqtt5</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3872,7 +3872,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3882,12 +3882,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-main</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-vertx</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3932,7 +3932,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-quartz</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3967,7 +3967,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ref</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3977,22 +3977,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-resilience4j</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-resourceresolver-github</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest-openapi</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4022,12 +4022,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saga</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-salesforce</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4042,12 +4042,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saxon</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-scheduler</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4057,7 +4057,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-seda</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4072,7 +4072,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-servlet</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4092,17 +4092,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-slack</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smb</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smooks</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4117,12 +4117,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-snmp</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-soap</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4132,22 +4132,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk-hec</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-batch</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4157,52 +4157,52 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-jdbc</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-ldap</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-main</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-rabbitmq</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-redis</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-security</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-ws</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-xml</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sql</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ssh</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4232,12 +4232,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stub</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-support</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4262,12 +4262,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-telegram</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-telemetry</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4282,12 +4282,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-junit5</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4297,7 +4297,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-spring-junit5</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4322,22 +4322,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-timer</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-maven</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-model</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-util</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4347,7 +4347,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tracing</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4362,12 +4362,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-undertow</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-undertow-spring-security</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4377,22 +4377,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util-json</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-validator</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-velocity</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4402,17 +4402,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-common</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-http</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-websocket</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4442,7 +4442,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-webhook</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4467,27 +4467,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xj</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-dsl</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-util</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxb</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4497,12 +4497,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp-util</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4517,37 +4517,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xpath</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt-saxon</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-common</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-deserializers</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-io</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4562,12 +4562,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zip-deflater</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zipfile</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4587,7 +4587,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>spi-annotations</artifactId>
-        <version>4.14.1.redhat-00005</version>
+        <version>4.14.1.redhat-00008</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>

--- a/tooling/redhat-camel-spring-boot-bom/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom/pom.xml
@@ -74,12 +74,12 @@
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-api</artifactId>
-                <version>4.14.1.redhat-00005</version>
+                <version>4.14.1.redhat-00008</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-support</artifactId>
-                <version>4.14.1.redhat-00005</version>
+                <version>4.14.1.redhat-00008</version>
             </dependency>
 
             <!-- Insert third party overrides here -->
@@ -132,17 +132,17 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-access</artifactId>
-                <version>1.5.18</version>
+                <version>1.5.19</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.5.18</version>
+                <version>1.5.19</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
-                <version>1.5.18</version>
+                <version>1.5.19</version>
             </dependency>
             <dependency>
                 <groupId>commons-beanutils</groupId>
@@ -194,7 +194,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.28.0.redhat-00001</version>
+                <version>1.28.0.redhat-00002</version>
             </dependency>
             <!-- Overrides snappy-java -->
             <dependency>
@@ -230,7 +230,7 @@
             <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-bom</artifactId>
-                <version>6.5.5</version>
+                <version>6.5.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -238,7 +238,7 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-framework-bom</artifactId>
-                <version>6.2.11</version>
+                <version>6.2.12</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -246,7 +246,7 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-bom</artifactId>
-                <version>12.0.27.redhat-00001</version>
+                <version>12.0.29.redhat-00001</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -507,7 +507,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-sdk-bom</artifactId>
-                <version>1.2.37</version>
+                <version>1.2.37.redhat-00001</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -516,7 +516,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-bom</artifactId>
-                <version>4.1.3.rhbac-redhat-00013</version>
+                <version>4.1.3.rhbac-redhat-00018</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/CSB-7688

Marco brought up that this starter has not been productized, though the camel component has been productized.     Adding it to the list of productized starters.      The dependency:tree for the camel-azure-storage-datalake camel component looks good - only productized dependencies with the exception of a few test scope dependencies like mockito.