### PR TITLE
Remove the CODEOWNERS file, it does not appear to be needed for public repos

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @jboss-fuse/csb-reviewers


### PR DESCRIPTION
I thought we might need this but it looks like the only place where we are limited to one reviewer per PR is private repos (camel and cxf).     I think we can safely remove this.