### PR TITLE
Remove deploy-maven-plugin from bom generator, it may not be needed

### DIFF
--- a/tooling/camel-spring-boot-bom/pom.xml
+++ b/tooling/camel-spring-boot-bom/pom.xml
@@ -36,32 +36,32 @@
       <dependency>
         <groupId>dev.snowdrop</groupId>
         <artifactId>narayana-spring-boot-core</artifactId>
-        <version>3.2.0.redhat-00006</version>
+        <version>3.5.0.redhat-00017</version>
       </dependency>
       <dependency>
         <groupId>dev.snowdrop</groupId>
         <artifactId>narayana-spring-boot-recovery-controller</artifactId>
-        <version>3.2.0.redhat-00006</version>
+        <version>3.5.0.redhat-00017</version>
       </dependency>
       <dependency>
         <groupId>dev.snowdrop</groupId>
         <artifactId>narayana-spring-boot-starter</artifactId>
-        <version>3.2.0.redhat-00006</version>
+        <version>3.5.0.redhat-00017</version>
       </dependency>
       <dependency>
         <groupId>io.agroal</groupId>
         <artifactId>agroal-api</artifactId>
-        <version>2.5</version>
+        <version>2.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>io.agroal</groupId>
         <artifactId>agroal-pool</artifactId>
-        <version>2.5</version>
+        <version>2.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>io.agroal</groupId>
         <artifactId>agroal-spring-boot-starter</artifactId>
-        <version>2.5</version>
+        <version>2.8.0.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -69,17 +69,17 @@
       <dependency>
         <groupId>dev.snowdrop</groupId>
         <artifactId>narayana-spring-boot-core</artifactId>
-        <version>3.2.0.redhat-00006</version>
+        <version>3.5.0.redhat-00017</version>
       </dependency>
       <dependency>
         <groupId>dev.snowdrop</groupId>
         <artifactId>narayana-spring-boot-recovery-controller</artifactId>
-        <version>3.2.0.redhat-00006</version>
+        <version>3.5.0.redhat-00017</version>
       </dependency>
       <dependency>
         <groupId>dev.snowdrop</groupId>
         <artifactId>narayana-spring-boot-starter</artifactId>
-        <version>3.2.0.redhat-00006</version>
+        <version>3.5.0.redhat-00017</version>
       </dependency>
       <dependency>
         <groupId>io.grpc</groupId>
@@ -4753,7 +4753,7 @@
       <dependency>
         <groupId>org.eclipse.jkube</groupId>
         <artifactId>openshift-maven-plugin</artifactId>
-        <version>1.18.1.redhat-00007</version>
+        <version>1.18.2.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.parsson</groupId>
@@ -4763,7 +4763,7 @@
       <dependency>
         <groupId>org.fusesource</groupId>
         <artifactId>camel-cics</artifactId>
-        <version>4.10.0.redhat-00005</version>
+        <version>4.14.2.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.fusesource</groupId>
@@ -4773,7 +4773,7 @@
       <dependency>
         <groupId>org.fusesource</groupId>
         <artifactId>camel-sap</artifactId>
-        <version>4.10.0.redhat-00005</version>
+        <version>4.14.2.redhat-00001</version>
       </dependency>
       <dependency>
         <groupId>org.fusesource</groupId>

--- a/tooling/redhat-camel-spring-boot-bom-generator/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/pom.xml
@@ -90,26 +90,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins </groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>deploy-file</id>
-                        <phase>deploy</phase>
-                        <goals>
-                            <goal>deploy-file</goal>
-                        </goals>
-                        <configuration>
-                            <file>${project.build.directory}/redhat-camel-spring-boot-bom/pom.xml</file>
-                            <groupId>com.redhat.camel.springboot.platform</groupId>
-                            <artifactId>camel-spring-boot-bom</artifactId>
-                            <version>${project.version}</version>
-                            <packaging>pom</packaging>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Getting an error here in PNC on the use of deploy-maven-plugin, which seems like it may not be needed - 

https://orch-secondary.pnc.engineering.redhat.com/pnc-web/#/projects/1128/build-configs/19774/builds/BLES3QWHALAAI/build-log

The deploy-maven-plugin use was added in https://github.com/jboss-fuse/camel-spring-boot/commit/06baca84ec0bb3a921de555c45d9bb9431c42925 to try to remove the intermediate bom from being checked in.     I think maybe the maven-install-plugin usage may be enough to deploy the bom.