### PR TITLE
Add camel-opentelemetry2-starter to the required prod list.

### DIFF
--- a/product/src/main/resources/required-productized-camel-artifacts.txt
+++ b/product/src/main/resources/required-productized-camel-artifacts.txt
@@ -114,6 +114,7 @@ camel-openai-starter
 camel-openapi-java-starter
 camel-opensearch-starter
 camel-opentelemetry-starter
+camel-opentelemetry2-starter
 camel-paho-starter
 camel-paho-mqtt5-starter
 camel-platform-http-starter


### PR DESCRIPTION
The module was enabled but was not added to the required prod list - https://github.com/jboss-fuse/camel-spring-boot/blob/camel-spring-boot-4.18.0-branch/components-starter/pom.xml#L390