### PR TITLE
Exclude org.glassfish.jaxb:jaxb-runtime from camel-debezium-oracle-starter

### DIFF
--- a/tooling/camel-spring-boot-bom/pom.xml
+++ b/tooling/camel-spring-boot-bom/pom.xml
@@ -572,6 +572,12 @@
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-debezium-oracle-starter</artifactId>
         <version>4.18.1</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>

--- a/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomGeneratorMojo.java
+++ b/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomGeneratorMojo.java
@@ -296,6 +296,22 @@ public class BomGeneratorMojo extends AbstractMojo {
 
         outDependencies.sort(Comparator.comparing(d -> (d.getGroupId() + ":" + d.getArtifactId())));
 
+        // Add exclusions for specific dependencies
+        // ehcache:3.11.1 declares version range [2.2,3) for jaxb-runtime,
+        // resolved to pre-release 2.3.0-b170127.1453 which pulls jaxb-api
+        // from defunct HTTP-only repos (maven.java.net), blocked since
+        // Maven 3.8.1+. Not needed at runtime on Java 11+.
+        // See: https://github.com/ehcache/ehcache3/issues/3215
+        outDependencies.stream()
+                .filter(d -> "camel-debezium-oracle-starter".equals(d.getArtifactId()))
+                .findFirst()
+                .ifPresent(d -> {
+                    Exclusion exclusion = new Exclusion();
+                    exclusion.setGroupId("org.glassfish.jaxb");
+                    exclusion.setArtifactId("jaxb-runtime");
+                    d.addExclusion(exclusion);
+                });
+
         // include some dependencies for testing and management
         dep = new Dependency();
         dep.setGroupId("org.apache.camel");


### PR DESCRIPTION
The fix here https://github.com/jboss-fuse/camel/commit/b0c8b5440f591c70830d0cd85349df345f3448fd won't work because camel-debezium-oracle is an unsupported component - we don't build it in camel so the exclude won't show up.   

The only way I can think of to add this exclusion is to target the starter in the camel-spring-boot-bom using the bom generator.    Add the exclusion as an exception in the bom generator logic.