### PR TITLE
Add overrides for activemq / activemq6 artifacts used within camel

### DIFF
--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -149,6 +149,18 @@
                 <artifactId>commons-beanutils</artifactId>
                 <version>${commons-beanutils-version}</version>
             </dependency>
+            <!-- Overrides for activemq -->
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-client-jakarta</artifactId>
+                <version>${activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-client</artifactId>
+                <version>${activemq6-version}</version>
+            </dependency>
+
             <!-- Override for org.json:json -->
             <dependency>
                 <groupId>org.json</groupId>


### PR DESCRIPTION
https://github.com/jboss-fuse/camel/commit/650b5f035ba2a8419f6c770c977d70db6519f4cd added new activemq / activemq6 versions to camel-parent, but these are unsupported components : https://github.com/jboss-fuse/camel/blob/camel-4.18.1-branch/components/pom.xml#L80-L81

We want to use these updated versions so we need to override the platform bom with them.

The only place activemq-version is used in camel or camel-spring-boot is : https://github.com/jboss-fuse/camel/blob/camel-4.18.1-branch/components/camel-activemq/pom.xml#L48-L52

The only place activemq6-version is use in camel or camel-spring-boot is : https://github.com/jboss-fuse/camel/blob/camel-4.18.1-branch/components/camel-activemq6/pom.xml#L49-L53

Normally we add a bom but because we are trying to fix both activemq 5 and activemq 6 we should probably stick to just the artifacts used to prevent version collision.