### PR TITLE
Remove junit6 from bom, use junit5 with camel-platform-http-starter, upgrade camel version

### DIFF
--- a/components-starter/camel-amqp-starter/src/main/java/org/apache/camel/component/amqp/springboot/AMQPComponentConfiguration.java
+++ b/components-starter/camel-amqp-starter/src/main/java/org/apache/camel/component/amqp/springboot/AMQPComponentConfiguration.java
@@ -845,6 +845,19 @@ public class AMQPComponentConfiguration
      */
     private Boolean errorHandlerLogStackTrace = true;
     /**
+     * Sets an ObjectInputFilter pattern (jdk.serialFilter syntax) applied as a
+     * defense-in-depth check on the class of the body returned by
+     * jakarta.jms.ObjectMessage.getObject(). The pattern is evaluated after the
+     * JMS provider has deserialized the payload, so this option alone does not
+     * prevent gadget-chain execution that happens inside the provider's
+     * ObjectInputStream; to block such attacks, also configure the JMS
+     * provider's own deserialization filter and/or the JVM-wide
+     * -Djdk.serialFilter. When this option is not set and no JVM-wide filter is
+     * configured, a conservative default filter allowing java., javax. and
+     * org.apache.camel. is applied.
+     */
+    private String deserializationFilter;
+    /**
      * The SSL keystore password.
      */
     private String keyStorePassword;
@@ -1796,6 +1809,14 @@ public class AMQPComponentConfiguration
 
     public void setErrorHandlerLogStackTrace(Boolean errorHandlerLogStackTrace) {
         this.errorHandlerLogStackTrace = errorHandlerLogStackTrace;
+    }
+
+    public String getDeserializationFilter() {
+        return deserializationFilter;
+    }
+
+    public void setDeserializationFilter(String deserializationFilter) {
+        this.deserializationFilter = deserializationFilter;
     }
 
     public String getKeyStorePassword() {

--- a/components-starter/camel-jms-starter/src/main/java/org/apache/camel/component/jms/springboot/JmsComponentConfiguration.java
+++ b/components-starter/camel-jms-starter/src/main/java/org/apache/camel/component/jms/springboot/JmsComponentConfiguration.java
@@ -800,6 +800,19 @@ public class JmsComponentConfiguration
      */
     private Boolean errorHandlerLogStackTrace = true;
     /**
+     * Sets an ObjectInputFilter pattern (jdk.serialFilter syntax) applied as a
+     * defense-in-depth check on the class of the body returned by
+     * jakarta.jms.ObjectMessage.getObject(). The pattern is evaluated after the
+     * JMS provider has deserialized the payload, so this option alone does not
+     * prevent gadget-chain execution that happens inside the provider's
+     * ObjectInputStream; to block such attacks, also configure the JMS
+     * provider's own deserialization filter and/or the JVM-wide
+     * -Djdk.serialFilter. When this option is not set and no JVM-wide filter is
+     * configured, a conservative default filter allowing java., javax. and
+     * org.apache.camel. is applied.
+     */
+    private String deserializationFilter;
+    /**
      * Password to use with the ConnectionFactory. You can also configure
      * username/password directly on the ConnectionFactory.
      */
@@ -1663,6 +1676,14 @@ public class JmsComponentConfiguration
 
     public void setErrorHandlerLogStackTrace(Boolean errorHandlerLogStackTrace) {
         this.errorHandlerLogStackTrace = errorHandlerLogStackTrace;
+    }
+
+    public String getDeserializationFilter() {
+        return deserializationFilter;
+    }
+
+    public void setDeserializationFilter(String deserializationFilter) {
+        this.deserializationFilter = deserializationFilter;
     }
 
     public String getPassword() {

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/PlatformHttpBinaryUploadTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/PlatformHttpBinaryUploadTest.java
@@ -19,7 +19,7 @@ package org.apache.camel.component.platform.http.springboot;
 import io.restassured.RestAssured;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
-import org.apache.camel.test.spring.junit6.CamelSpringBootTest;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpHeaderFilterStrategyTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpHeaderFilterStrategyTest.java
@@ -20,7 +20,7 @@ import io.restassured.RestAssured;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.http.common.HttpHeaderFilterStrategy;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
-import org.apache.camel.test.spring.junit6.CamelSpringBootTest;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpResponseCodeTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpResponseCodeTest.java
@@ -20,7 +20,7 @@ import io.restassured.RestAssured;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
-import org.apache.camel.test.spring.junit6.CamelSpringBootTest;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dependencies</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
     </parent>
 
     <groupId>org.apache.camel.springboot</groupId>
@@ -138,7 +138,7 @@
         <!-- spring-boot-version is now maintained in camel/parent/pom.xml https://github.com/apache/camel/blob/main/parent/pom.xml#L484 -->
 
         <!-- Camel target version -->
-        <camel-version>4.18.1.redhat-00002</camel-version>
+        <camel-version>4.18.1.redhat-00015</camel-version>
 
         <!-- versions -->
         <aether-version>1.0.2.v20150114</aether-version>

--- a/tooling/camel-spring-boot-bom/pom.xml
+++ b/tooling/camel-spring-boot-bom/pom.xml
@@ -2194,11 +2194,6 @@
         <artifactId>camel-test-spring-junit5</artifactId>
         <version>${camel-version}</version>
       </dependency>
-      <dependency>
-        <groupId>org.apache.camel</groupId>
-        <artifactId>camel-test-spring-junit6</artifactId>
-        <version>${camel-version}</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -290,17 +290,17 @@
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-debezium-maven-plugin</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-salesforce-maven-plugin</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.maven</groupId>
         <artifactId>camel-servicenow-maven-plugin</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.springboot</groupId>
@@ -2410,18 +2410,18 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-allcomponents</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-amqp</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-api</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2461,12 +2461,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-attachments</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-avro</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2496,7 +2496,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-common</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2511,7 +2511,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws-secrets-manager</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2536,12 +2536,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-cw</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-ddb</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2571,7 +2571,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-kinesis</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2581,7 +2581,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-lambda</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2611,7 +2611,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-s3</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2626,12 +2626,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sns</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-aws2-sqs</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2676,7 +2676,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-eventhubs</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2686,7 +2686,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-key-vault</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2696,22 +2696,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-servicebus</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-blob</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-datalake</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-azure-storage-queue</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2721,12 +2721,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-base-engine</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2736,22 +2736,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bean-validator</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-beanio</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-bindy</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2776,7 +2776,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-browse</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2786,17 +2786,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cassandraql</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog-console</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2811,7 +2811,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-catalog-suggest</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2831,7 +2831,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cli-connector</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2846,17 +2846,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloud</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cloudevents</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cluster</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2876,12 +2876,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-componentdsl</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-console</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2891,12 +2891,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-controlbus</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2907,37 +2907,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-catalog</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-engine</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-languages</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-model</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-processor</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-reifier</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-core-xml</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2952,17 +2952,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cron</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-crypto</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-crypto-pgp</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2982,42 +2982,42 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-common</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-rest</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-soap</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-common</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-rest</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-soap</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-spring-transport</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-cxf-transport</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3032,12 +3032,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataformat</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dataset</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3082,7 +3082,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-debug</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3107,7 +3107,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-direct</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3132,7 +3132,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-docling</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3147,12 +3147,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-modeline</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dsl-support</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3167,12 +3167,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-elasticsearch-rest-client</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3182,12 +3182,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-endpointdsl-support</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3202,22 +3202,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-fhir-api</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-file</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-file-watch</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3227,7 +3227,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-flink</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3252,7 +3252,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ftp</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3277,7 +3277,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-bigquery</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3302,7 +3302,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-pubsub</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3312,7 +3312,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-google-secret-manager</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3337,7 +3337,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-graphql</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3347,7 +3347,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-groovy</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3357,12 +3357,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-grpc</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-gson</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3372,7 +3372,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hashicorp-vault</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3387,27 +3387,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-health</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-hl7</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-base</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-http-common</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3507,17 +3507,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-common</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-infinispan-embedded</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3547,22 +3547,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-avro</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jackson-protobuf</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jacksonxml</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3572,12 +3572,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jasypt</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-java-joor-dsl</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3587,32 +3587,32 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jaxb</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbang-console</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbang-core</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbang-main</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbang-plugin-generate</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbang-plugin-kubernetes</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3622,7 +3622,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jbang-plugin-test</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3637,7 +3637,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jdbc</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3652,7 +3652,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jfr</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3667,12 +3667,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jira</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jms</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3692,17 +3692,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-joor</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jpa</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jq</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3712,7 +3712,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jslt</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3742,17 +3742,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jsonpath</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jt400</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-jta</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3762,17 +3762,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kafka</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kamelet-main</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3782,17 +3782,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-api</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-knative-http</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3802,12 +3802,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kubernetes</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-kudu</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3862,12 +3862,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-language</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ldap</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3882,12 +3882,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-log</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-lra</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3907,37 +3907,37 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mail-microsoft-oauth</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-main</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-management-api</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mapstruct</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-master</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3952,7 +3952,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-micrometer</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3962,22 +3962,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-micrometer-prometheus</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-config</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-fault-tolerance</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-microprofile-health</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3987,7 +3987,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-milvus</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -3997,27 +3997,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mina-sftp</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-minio</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mllp</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mock</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mongodb</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4037,12 +4037,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-mybatis</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-nats</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4052,12 +4052,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-netty-http</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4077,7 +4077,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-observability-services</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4107,12 +4107,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-olingo4-api</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4122,27 +4122,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openai</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-java</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-rest-dsl-generator</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-openapi-validator</artifactId>
-        <version>4.18.1</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opensearch</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4152,7 +4152,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opentelemetry</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4162,7 +4162,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opentelemetry2</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4172,12 +4172,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-paho-mqtt5</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4207,22 +4207,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-jolokia</artifactId>
-        <version>4.18.1</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-main</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-platform-http-vertx</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4262,12 +4262,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-qdrant</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-quartz</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4302,7 +4302,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ref</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4312,7 +4312,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-resilience4j</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4322,17 +4322,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-resourceresolver-github</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-rest-openapi</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4362,12 +4362,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saga</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-salesforce</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4382,12 +4382,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-saxon</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-scheduler</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4397,7 +4397,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-seda</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4412,7 +4412,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-servlet</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4432,17 +4432,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-slack</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smb</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-smooks</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4457,12 +4457,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-snmp</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-soap</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4472,17 +4472,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-splunk-hec</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4507,7 +4507,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-batch</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4517,52 +4517,52 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-jdbc</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-ldap</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-main</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-rabbitmq</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-redis</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-security</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-ws</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring-xml</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-sql</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-ssh</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4597,12 +4597,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-stub</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-support</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4627,12 +4627,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-telegram</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-telemetry</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4647,12 +4647,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-junit5</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-junit6</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4667,12 +4667,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-spring-junit5</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-spring-junit6</artifactId>
-        <version>4.18.1</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4697,22 +4697,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-timer</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-maven</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-model</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tooling-util</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4722,7 +4722,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-tracing</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4737,12 +4737,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-undertow</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-undertow-spring-security</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4752,22 +4752,22 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-util-json</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-validator</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-velocity</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4777,17 +4777,17 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-common</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-http</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-vertx-websocket</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4817,7 +4817,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-webhook</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4842,27 +4842,27 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xj</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-dsl</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-io-util</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxb</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4872,12 +4872,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xml-jaxp-util</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4892,42 +4892,42 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xpath</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-xslt-saxon</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-common</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-deserializers</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-dsl-validator</artifactId>
-        <version>4.18.1</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-yaml-io</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4942,12 +4942,12 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zip-deflater</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-zipfile</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -4967,7 +4967,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>spi-annotations</artifactId>
-        <version>4.18.1.redhat-00002</version>
+        <version>4.18.1.redhat-00015</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
@@ -5103,7 +5103,7 @@
       <dependency>
         <groupId>org.apache.tomcat</groupId>
         <artifactId>tomcat-catalina</artifactId>
-        <version>10.1.52</version>
+        <version>10.1.54</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>

--- a/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomGeneratorMojo.java
+++ b/tooling/camel-spring-boot-generator-maven-plugin/src/main/java/org/apache/camel/springboot/maven/BomGeneratorMojo.java
@@ -323,11 +323,6 @@ public class BomGeneratorMojo extends AbstractMojo {
         dep.setArtifactId("camel-test-spring-junit5");
         dep.setVersion("${camel-version}");
         outDependencies.add(dep);
-        dep = new Dependency();
-        dep.setGroupId("org.apache.camel");
-        dep.setArtifactId("camel-test-spring-junit6");
-        dep.setVersion("${camel-version}");
-        outDependencies.add(dep);
 
         return outDependencies;
     }


### PR DESCRIPTION
@Croway was right, we need to fix the junit6 imports in https://github.com/jboss-fuse/camel-spring-boot/pull/654

Remove junit6 from bom, use junit5 with camel-platform-http-starter, upgrade camel version.     Use junit5 as the default for testing camel-spring-boot - we should switch this to junit6 in the productized 4.19/4.20.