### PR TITLE
Backport platform-http fix for Spring Boot 3.5.14

### DIFF
--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/PlatformHttpComponentAutoConfiguration.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/PlatformHttpComponentAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Lazy;
 
 /**
@@ -47,13 +48,13 @@ public class PlatformHttpComponentAutoConfiguration {
 
     @Autowired
     private ApplicationContext applicationContext;
-    private final CamelContext camelContext;
+    private final ObjectProvider<CamelContext> camelContextProvider;
     @Autowired
     private PlatformHttpComponentConfiguration configuration;
 
     public PlatformHttpComponentAutoConfiguration(
-            org.apache.camel.CamelContext camelContext) {
-        this.camelContext = camelContext;
+            ObjectProvider<CamelContext> camelContextProvider) {
+        this.camelContextProvider = camelContextProvider;
     }
 
     @Lazy
@@ -62,7 +63,7 @@ public class PlatformHttpComponentAutoConfiguration {
         return new ComponentCustomizer() {
             @Override
             public void configure(String name, Component target) {
-                CamelPropertiesHelper.copyProperties(camelContext, configuration, target);
+                CamelPropertiesHelper.copyProperties(camelContextProvider.getObject(), configuration, target);
             }
             @Override
             public boolean isEnabled(String name, Component target) {

--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/PlatformHttpComponentAutoConfiguration.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/PlatformHttpComponentAutoConfiguration.java
@@ -33,7 +33,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Lazy;
 
 /**
@@ -48,13 +47,13 @@ public class PlatformHttpComponentAutoConfiguration {
 
     @Autowired
     private ApplicationContext applicationContext;
-    private final ObjectProvider<CamelContext> camelContextProvider;
+    private final CamelContext camelContext;
     @Autowired
     private PlatformHttpComponentConfiguration configuration;
 
     public PlatformHttpComponentAutoConfiguration(
-            ObjectProvider<CamelContext> camelContextProvider) {
-        this.camelContextProvider = camelContextProvider;
+            org.apache.camel.CamelContext camelContext) {
+        this.camelContext = camelContext;
     }
 
     @Lazy
@@ -63,7 +62,7 @@ public class PlatformHttpComponentAutoConfiguration {
         return new ComponentCustomizer() {
             @Override
             public void configure(String name, Component target) {
-                CamelPropertiesHelper.copyProperties(camelContextProvider.getObject(), configuration, target);
+                CamelPropertiesHelper.copyProperties(camelContext, configuration, target);
             }
             @Override
             public boolean isEnabled(String name, Component target) {

--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpAutoConfiguration.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpAutoConfiguration.java
@@ -28,7 +28,7 @@ import org.springframework.boot.autoconfigure.web.servlet.WebMvcProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.DependsOn;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.core.env.Environment;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -96,8 +96,8 @@ public class SpringBootPlatformHttpAutoConfiguration {
     }
 
     @Bean
-    @DependsOn("configurePlatformHttpComponent")
-    public CamelRequestHandlerMapping platformHttpEngineRequestMapping(PlatformHttpEngine engine, CamelContext camelContext) {
+    public CamelRequestHandlerMapping platformHttpEngineRequestMapping(PlatformHttpEngine engine, ObjectProvider<CamelContext> camelContextProvider) {
+        CamelContext camelContext = camelContextProvider.getObject();
         PlatformHttpComponent component = camelContext.getComponent("platform-http", PlatformHttpComponent.class);
         CamelRequestHandlerMapping answer = new CamelRequestHandlerMapping(component, engine);
         return answer;

--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpConsumer.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpConsumer.java
@@ -16,7 +16,6 @@
  */
 package org.apache.camel.component.platform.http.springboot;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
@@ -40,8 +39,11 @@ import org.apache.camel.http.common.HttpHelper;
 import org.apache.camel.support.DefaultConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.scheduling.concurrent.ConcurrentTaskExecutor;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.context.request.async.WebAsyncTask;
 
 public class SpringBootPlatformHttpConsumer extends DefaultConsumer implements PlatformHttpConsumer, Suspendable, SuspendableService {
 
@@ -84,11 +86,14 @@ public class SpringBootPlatformHttpConsumer extends DefaultConsumer implements P
     /**
      * This method is invoked by Spring Boot when invoking Camel via platform-http.
      *
-     * Returns a Callable to integrate with Spring MVC async request lifecycle.
+     * Returns a WebAsyncTask to integrate with Spring MVC async lifecycle while preserving the custom executor.
      */
     @ResponseBody
-    public Callable<Void> service(HttpServletRequest request, HttpServletResponse response) {
-        return () -> {
+    public WebAsyncTask<Void> service(HttpServletRequest request, HttpServletResponse response) {
+        AsyncTaskExecutor asyncExecutor = (executor instanceof AsyncTaskExecutor ate)
+                ? ate
+                : new ConcurrentTaskExecutor(executor);
+        WebAsyncTask<Void> task = new WebAsyncTask<>(null, asyncExecutor, () -> {
             LOG.trace("Service: {}", request);
             try {
                 handleService(request, response);
@@ -104,7 +109,14 @@ public class SpringBootPlatformHttpConsumer extends DefaultConsumer implements P
                 }
             }
             return null;
-        };
+        });
+        task.onTimeout(() -> {
+            if (!response.isCommitted()) {
+                response.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+            }
+            return null;
+        });
+        return task;
     }
 
     protected void handleService(HttpServletRequest request, HttpServletResponse response) throws Exception {

--- a/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpConsumer.java
+++ b/components-starter/camel-platform-http-starter/src/main/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpConsumer.java
@@ -16,7 +16,7 @@
  */
 package org.apache.camel.component.platform.http.springboot;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
@@ -84,13 +84,11 @@ public class SpringBootPlatformHttpConsumer extends DefaultConsumer implements P
     /**
      * This method is invoked by Spring Boot when invoking Camel via platform-http.
      *
-     * The method is already running asynchronously via AsyncExecutionInterceptor.
-     *
-     * Returns an empty CompletableFuture as per documentation https://spring.io/guides/gs/async-method
+     * Returns a Callable to integrate with Spring MVC async request lifecycle.
      */
     @ResponseBody
-    public CompletableFuture<Void> service(HttpServletRequest request, HttpServletResponse response) {
-        return CompletableFuture.runAsync(() -> {
+    public Callable<Void> service(HttpServletRequest request, HttpServletResponse response) {
+        return () -> {
             LOG.trace("Service: {}", request);
             try {
                 handleService(request, response);
@@ -105,7 +103,8 @@ public class SpringBootPlatformHttpConsumer extends DefaultConsumer implements P
                     // ignore
                 }
             }
-        }, executor);
+            return null;
+        };
     }
 
     protected void handleService(HttpServletRequest request, HttpServletResponse response) throws Exception {

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/PlatformHttpBinaryUploadTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/PlatformHttpBinaryUploadTest.java
@@ -26,7 +26,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -56,9 +57,8 @@ public class PlatformHttpBinaryUploadTest {
 
     static final String FILE_NAME = "example.pdf";
     static Path uploadDir;
-
-    @LocalServerPort
-    private int port;
+    @Autowired
+    private Environment environment;
 
     @BeforeAll
     public static void createUploadDir() throws IOException {
@@ -73,7 +73,7 @@ public class PlatformHttpBinaryUploadTest {
 
     @BeforeEach
     public void setUp() {
-        RestAssured.port = port;
+        RestAssured.port = Integer.parseInt(environment.getRequiredProperty("local.server.port"));
     }
 
     @Test

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/PlatformHttpStreamingTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/PlatformHttpStreamingTest.java
@@ -28,7 +28,8 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -52,13 +53,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
         SpringBootPlatformHttpTest.class, PlatformHttpStreamingTest.TestConfiguration.class,
         PlatformHttpComponentAutoConfiguration.class, SpringBootPlatformHttpAutoConfiguration.class })
 public class PlatformHttpStreamingTest {
-
-    @LocalServerPort
-    private int port;
+    @Autowired
+    private Environment environment;
 
     @BeforeEach
     public void setUp() {
-        RestAssured.port = port;
+        RestAssured.port = Integer.parseInt(environment.getRequiredProperty("local.server.port"));
     }
 
     @Test

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpBridgedEndpointTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpBridgedEndpointTest.java
@@ -29,7 +29,8 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.wiremock.spring.ConfigureWireMock;
@@ -46,9 +47,8 @@ import static org.hamcrest.Matchers.containsString;
         PlatformHttpComponentAutoConfiguration.class, SpringBootPlatformHttpAutoConfiguration.class, HttpComponentAutoConfiguration.class})
 @EnableWireMock(@ConfigureWireMock(portProperties = "customPort"))
 public class SpringBootPlatformHttpBridgedEndpointTest {
-
-    @LocalServerPort
-    private Integer port;
+    @Autowired
+    private Environment environment;
 
     @BeforeEach
     void setUp() {
@@ -83,7 +83,7 @@ public class SpringBootPlatformHttpBridgedEndpointTest {
 
     @Test
     public void bridgedEndpointTest() {
-        final var proxyURI = "http://localhost:%s/mock".formatted(port);
+        final var proxyURI = "http://localhost:%s/mock".formatted(Integer.parseInt(environment.getRequiredProperty("local.server.port")));
 
         given()
                 .contentType(ContentType.JSON)

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCamelIntegrationsTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCamelIntegrationsTest.java
@@ -30,7 +30,8 @@ import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2Clien
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -48,13 +49,12 @@ public class SpringBootPlatformHttpCamelIntegrationsTest {
 
     @Autowired
     CamelContext camelContext;
-
-    @LocalServerPort
-    private Integer port;
+    @Autowired
+    private Environment environment;
 
     @BeforeEach
     void setUp() {
-        RestAssured.port = port;
+        RestAssured.port = Integer.parseInt(environment.getRequiredProperty("local.server.port"));
     }
 
     @Configuration

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCertificationTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCertificationTest.java
@@ -54,7 +54,8 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -73,13 +74,12 @@ public class SpringBootPlatformHttpCertificationTest extends PlatformHttpBase {
 
     private static final String postRouteId = "SpringBootPlatformHttpRestDSLTest_mypost";
     private static final String getRouteId = "SpringBootPlatformHttpRestDSLTest_myget";
-
-    @LocalServerPort
-    private Integer port;
+    @Autowired
+    private Environment environment;
 
     @BeforeEach
     void setUp() {
-        RestAssured.port = port;
+        RestAssured.port = Integer.parseInt(environment.getRequiredProperty("local.server.port"));
     }
 
     @Configuration

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpContextPathTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpContextPathTest.java
@@ -26,7 +26,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -44,13 +45,12 @@ import static org.hamcrest.Matchers.equalTo;
                 SpringBootPlatformHttpAutoConfiguration.class },
         properties = { "server.servlet.context-path=/test", "camel.rest.context-path=/api" })
 public class SpringBootPlatformHttpContextPathTest {
-
-    @LocalServerPort
-    private Integer port;
+    @Autowired
+    private Environment environment;
 
     @BeforeEach
     void setUp() {
-        RestAssured.port = port;
+        RestAssured.port = Integer.parseInt(environment.getRequiredProperty("local.server.port"));
     }
 
     @Configuration

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCookiesTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCookiesTest.java
@@ -34,7 +34,8 @@ import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2Clien
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -56,13 +57,12 @@ public class SpringBootPlatformHttpCookiesTest {
 
     @Autowired
     CamelContext camelContext;
-
-    @LocalServerPort
-    private Integer port;
+    @Autowired
+    private Environment environment;
 
     @BeforeEach
     void setUp() {
-        RestAssured.port = port;
+        RestAssured.port = Integer.parseInt(environment.getRequiredProperty("local.server.port"));
     }
 
     @Configuration

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCorsCredentialsTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCorsCredentialsTest.java
@@ -27,7 +27,8 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -40,13 +41,12 @@ import static org.hamcrest.Matchers.*;
         SpringBootPlatformHttpCorsCredentialsTest.class, SpringBootPlatformHttpCorsCredentialsTest.TestConfiguration.class,
         PlatformHttpComponentAutoConfiguration.class, SpringBootPlatformHttpAutoConfiguration.class, })
 public class SpringBootPlatformHttpCorsCredentialsTest {
-
-    @LocalServerPort
-    private Integer port;
+    @Autowired
+    private Environment environment;
 
     @BeforeEach
     void setUp() {
-        RestAssured.port = port;
+        RestAssured.port = Integer.parseInt(environment.getRequiredProperty("local.server.port"));
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     }
 

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCorsTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCorsTest.java
@@ -27,7 +27,8 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -42,13 +43,12 @@ import static org.hamcrest.Matchers.not;
         SpringBootPlatformHttpCorsTest.class, SpringBootPlatformHttpCorsTest.TestConfiguration.class,
         PlatformHttpComponentAutoConfiguration.class, SpringBootPlatformHttpAutoConfiguration.class, })
 public class SpringBootPlatformHttpCorsTest {
-
-    @LocalServerPort
-    private Integer port;
+    @Autowired
+    private Environment environment;
 
     @BeforeEach
     void setUp() {
-        RestAssured.port = port;
+        RestAssured.port = Integer.parseInt(environment.getRequiredProperty("local.server.port"));
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     }
 

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpEngineTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpEngineTest.java
@@ -34,7 +34,8 @@ import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2Clien
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -66,13 +67,12 @@ public class SpringBootPlatformHttpEngineTest {
 
     @Autowired
     CamelContext camelContext;
-
-    @LocalServerPort
-    private Integer port;
+    @Autowired
+    private Environment environment;
 
     @BeforeEach
     void setUp() {
-        RestAssured.port = port;
+        RestAssured.port = Integer.parseInt(environment.getRequiredProperty("local.server.port"));
     }
 
     private static final List<String> attachmentIds = new ArrayList<>();

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpHeaderFilterStrategyTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpHeaderFilterStrategyTest.java
@@ -25,7 +25,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -41,13 +42,12 @@ import static org.hamcrest.Matchers.equalTo;
         SpringBootPlatformHttpHeaderFilterStrategyTest.TestConfiguration.class,
         PlatformHttpComponentAutoConfiguration.class, SpringBootPlatformHttpAutoConfiguration.class })
 public class SpringBootPlatformHttpHeaderFilterStrategyTest {
-
-    @LocalServerPort
-    private Integer port;
+    @Autowired
+    private Environment environment;
 
     @BeforeEach
     void setUp() {
-        RestAssured.port = port;
+        RestAssured.port = Integer.parseInt(environment.getRequiredProperty("local.server.port"));
     }
 
     @Test

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpJacksonConverterTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpJacksonConverterTest.java
@@ -30,7 +30,8 @@ import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2Clien
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -49,13 +50,12 @@ public class SpringBootPlatformHttpJacksonConverterTest {
 
     @Autowired
     CamelContext camelContext;
-
-    @LocalServerPort
-    private Integer port;
+    @Autowired
+    private Environment environment;
 
     @BeforeEach
     void setUp() {
-        RestAssured.port = port;
+        RestAssured.port = Integer.parseInt(environment.getRequiredProperty("local.server.port"));
     }
 
     @Configuration

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpOptionsTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpOptionsTest.java
@@ -26,7 +26,8 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -39,13 +40,12 @@ import static org.hamcrest.Matchers.*;
         SpringBootPlatformHttpOptionsTest.class, SpringBootPlatformHttpOptionsTest.TestConfiguration.class,
         PlatformHttpComponentAutoConfiguration.class, SpringBootPlatformHttpAutoConfiguration.class, })
 public class SpringBootPlatformHttpOptionsTest {
-
-    @LocalServerPort
-    private Integer port;
+    @Autowired
+    private Environment environment;
 
     @BeforeEach
     void setUp() {
-        RestAssured.port = port;
+        RestAssured.port = Integer.parseInt(environment.getRequiredProperty("local.server.port"));
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     }
 

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpProxyTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpProxyTest.java
@@ -33,7 +33,8 @@ import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2Clien
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.wiremock.spring.ConfigureWireMock;
@@ -59,13 +60,12 @@ public class SpringBootPlatformHttpProxyTest {
 
     @Autowired
     CamelContext camelContext;
-
-    @LocalServerPort
-    private Integer port;
+    @Autowired
+    private Environment environment;
 
     @BeforeEach
     void setUp() {
-        RestAssured.port = port;
+        RestAssured.port = Integer.parseInt(environment.getRequiredProperty("local.server.port"));
         WireMock.stubFor(get(urlPathEqualTo("/"))
                 .willReturn(aResponse()
                         .withBody(

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpResponseCodeTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpResponseCodeTest.java
@@ -25,7 +25,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -41,13 +42,12 @@ import static org.hamcrest.Matchers.equalTo;
         SpringBootPlatformHttpResponseCodeTest.TestConfiguration.class,
         PlatformHttpComponentAutoConfiguration.class, SpringBootPlatformHttpAutoConfiguration.class })
 public class SpringBootPlatformHttpResponseCodeTest {
-
-    @LocalServerPort
-    private Integer port;
+    @Autowired
+    private Environment environment;
 
     @BeforeEach
     void setUp() {
-        RestAssured.port = port;
+        RestAssured.port = Integer.parseInt(environment.getRequiredProperty("local.server.port"));
     }
 
     @Test

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpServerRequestValidationFalseTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpServerRequestValidationFalseTest.java
@@ -27,7 +27,8 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -40,13 +41,12 @@ import static org.hamcrest.Matchers.is;
         SpringBootPlatformHttpServerRequestValidationFalseTest.class, SpringBootPlatformHttpServerRequestValidationFalseTest.TestConfiguration.class,
         PlatformHttpComponentAutoConfiguration.class, SpringBootPlatformHttpAutoConfiguration.class,})
 public class SpringBootPlatformHttpServerRequestValidationFalseTest {
-
-    @LocalServerPort
-    private Integer port;
+    @Autowired
+    private Environment environment;
 
     @BeforeEach
     void setUp() {
-        RestAssured.port = port;
+        RestAssured.port = Integer.parseInt(environment.getRequiredProperty("local.server.port"));
     }
 
     // *************************************

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpServerRequestValidationTrueTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpServerRequestValidationTrueTest.java
@@ -27,7 +27,8 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -40,13 +41,12 @@ import static org.hamcrest.Matchers.is;
         SpringBootPlatformHttpServerRequestValidationTrueTest.class, SpringBootPlatformHttpServerRequestValidationTrueTest.TestConfiguration.class,
         PlatformHttpComponentAutoConfiguration.class, SpringBootPlatformHttpAutoConfiguration.class,})
 public class SpringBootPlatformHttpServerRequestValidationTrueTest {
-
-    @LocalServerPort
-    private Integer port;
+    @Autowired
+    private Environment environment;
 
     @BeforeEach
     void setUp() {
-        RestAssured.port = port;
+        RestAssured.port = Integer.parseInt(environment.getRequiredProperty("local.server.port"));
     }
 
     // *************************************

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpSessionTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpSessionTest.java
@@ -31,7 +31,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -57,13 +58,12 @@ public class SpringBootPlatformHttpSessionTest {
 
     @Autowired
     CamelContext camelContext;
-
-    @LocalServerPort
-    private Integer port;
+    @Autowired
+    private Environment environment;
 
     @BeforeEach
     void setUp() {
-        RestAssured.port = port;
+        RestAssured.port = Integer.parseInt(environment.getRequiredProperty("local.server.port"));
     }
 
     @Configuration

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpTypeConverterTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpTypeConverterTest.java
@@ -29,7 +29,8 @@ import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2Clien
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -54,13 +55,12 @@ public class SpringBootPlatformHttpTypeConverterTest {
 
     @Autowired
     CamelContext camelContext;
-
-    @LocalServerPort
-    private Integer port;
+    @Autowired
+    private Environment environment;
 
     @BeforeEach
     void setUp() {
-        RestAssured.port = port;
+        RestAssured.port = Integer.parseInt(environment.getRequiredProperty("local.server.port"));
     }
 
     @Configuration

--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpValidationTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpValidationTest.java
@@ -35,7 +35,8 @@ import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2Clien
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -58,13 +59,12 @@ public class SpringBootPlatformHttpValidationTest {
 
     @Autowired
     CamelContext camelContext;
-
-    @LocalServerPort
-    private Integer port;
+    @Autowired
+    private Environment environment;
 
     @BeforeEach
     void setUp() {
-        RestAssured.port = port;
+        RestAssured.port = Integer.parseInt(environment.getRequiredProperty("local.server.port"));
     }
 
     @Configuration


### PR DESCRIPTION
## Summary

Cherry-pick of upstream commits [`36af212`](https://github.com/apache/camel-spring-boot/commit/36af212) and [`d8e1581`](https://github.com/apache/camel-spring-boot/commit/d8e1581) from `camel-spring-boot-4.18.x` (by Croway, May 4 2026).

Fixes 68 `platform-http-springboot` test failures caused by Spring Boot 3.5.14 incompatibility (ApplicationContext load failure).

**Production changes:**
- `SpringBootPlatformHttpAutoConfiguration`: removes `@DependsOn`, uses `ObjectProvider<CamelContext>`
- `SpringBootPlatformHttpConsumer`: replaces `CompletableFuture<Void>` with `WebAsyncTask<Void>`, adds 503 timeout handling

**Test changes:**
- 20 test files: replaces `@LocalServerPort` with `Environment.getRequiredProperty("local.server.port")`

## Test plan

- [x] Local build: 106/107 tests pass, 1 pre-existing failure (`PlatformHttpBinaryUploadTest` — missing `spring-security` dep, fails identically on midstream before this PR)
- [ ] CS5 re-spin should verify the 68 downstream-tests failures are resolved

Jira: [CSB-9140](https://redhat.atlassian.net/browse/CSB-9140)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>