### PR TITLE
Add MVNW_REPOURL to route maven zip downloads through RH nexus

### DIFF
--- a/Jenkinsfile.redhat
+++ b/Jenkinsfile.redhat
@@ -28,6 +28,7 @@ pipeline {
 
     environment {
         MAVEN_OPTS = '-Xmx3g'
+        MVNW_REPOURL = 'https://nexus.corp.redhat.com/repository/maven-central/'
     }
 
     options {


### PR DESCRIPTION
Getting test failures on 429 errors trying to download the maven zip - trying to fix it with MVNW_REPOURL