### PR TITLE
Add openshift-maven-plugin to pluginManagement for PME alignment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -613,6 +613,11 @@
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>${build-helper-maven-plugin-version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.eclipse.jkube</groupId>
+                    <artifactId>openshift-maven-plugin</artifactId>
+                    <version>${openshift-maven-plugin-version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
The `openshift-maven-plugin-version` property is not aligned by PME because nothing in the reactor references it as a plugin version. Adding a `<pluginManagement>` entry ensures PME detects and aligns the property automatically during PNC builds.

Without this, the archetype-generated projects get a stale jkube version that doesn't exist in the MRRC.