### PR TITLE
chore: align maven-surefire-plugin with Spring Boot 4.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <license-maven-plugin-version>5.0.0</license-maven-plugin-version>
         <maven-compiler-plugin-version>3.15.0</maven-compiler-plugin-version>
         <maven-javadoc-plugin-version>3.12.0</maven-javadoc-plugin-version>
-        <maven-surefire-plugin-version>3.5.5</maven-surefire-plugin-version>
+        <maven-surefire-plugin-version>3.5.6</maven-surefire-plugin-version>
         <springdoc-version>3.0.2</springdoc-version>
         <surefire.version>${maven-surefire-plugin-version}</surefire.version>
         <cyclonedx-maven-plugin-version>2.9.1</cyclonedx-maven-plugin-version>


### PR DESCRIPTION
## Summary

- Bump `maven-surefire-plugin-version` from 3.5.5 to 3.5.6 to match Spring Boot 4.0.7 BOM

All other dependency versions are inherited from camel-parent (see jboss-fuse/camel#3088).