### PR TITLE
chore: align dependency versions with Spring Boot 3.5.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,14 +150,14 @@
         <jaxb-version>2.3.0</jaxb-version>
         <maven-compiler-plugin-version>3.15.0</maven-compiler-plugin-version>
         <maven-javadoc-plugin-version>3.12.0</maven-javadoc-plugin-version>
-        <maven-surefire-plugin-version>3.5.5</maven-surefire-plugin-version>
+        <maven-surefire-plugin-version>3.5.6</maven-surefire-plugin-version>
         <mycila-license-version>5.0.0</mycila-license-version>
         <springdoc-version>2.2.0</springdoc-version>
         <surefire.version>${maven-surefire-plugin-version}</surefire.version>
         <swagger-parser-v3-version>2.1.10</swagger-parser-v3-version>
         <cyclonedx-maven-plugin-version>2.9.1</cyclonedx-maven-plugin-version>
         <wiremock-spring-boot-version>3.10.6</wiremock-spring-boot-version>
-        <spring-session-hazelcast-version>3.5.5</spring-session-hazelcast-version>
+        <spring-session-hazelcast-version>3.5.7</spring-session-hazelcast-version>
     </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
## Summary
- Bump maven-surefire-plugin from 3.5.5 to 3.5.6
- Bump spring-session-hazelcast from 3.5.5 to 3.5.7