### PR TITLE
ci: fix Spring Security config in platform-http tests

### DIFF
--- a/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpTest.java
+++ b/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpTest.java
@@ -20,13 +20,13 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
 
-@EnableAutoConfiguration(exclude = {OAuth2ClientAutoConfiguration.class, SecurityAutoConfiguration.class})
+@EnableAutoConfiguration
 @CamelSpringBootTest
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = { CamelAutoConfiguration.class,
         SpringBootPlatformHttpTest.class, SpringBootPlatformHttpTest.TestConfiguration.class,
@@ -42,6 +42,13 @@ public class SpringBootPlatformHttpTest extends PlatformHttpBase {
     // *************************************
     @Configuration
     public static class TestConfiguration {
+
+        @Bean
+        public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .csrf(csrf -> csrf.disable());
+            return http.build();
+        }
 
         @Bean
         public RouteBuilder servletPlatformHttpRouteBuilder() {


### PR DESCRIPTION
## Summary
- Backport of apache/camel-spring-boot@a780705 to fix `PlatformHttpBinaryUploadTest` context failure
- `SpringBootPlatformHttpTest` was excluding `SecurityAutoConfiguration`, but `PlatformHttpBinaryUploadTest` (which shares the same context) declares a `SecurityFilterChain` bean that needs Spring Security active
- Replaces the `@EnableAutoConfiguration(exclude = ...)` approach with an explicit permissive `SecurityFilterChain` bean (standard Spring Security 6.x pattern)

## Test plan
- [ ] `mvn verify` in `components-starter/camel-platform-http-starter` passes
- [ ] `PlatformHttpBinaryUploadTest.testBinaryPdfUpload` no longer fails with `ApplicationContext failure threshold exceeded`

🤖 Generated with [Claude Code](https://claude.com/claude-code)