### PR TITLE
Vertx version override

### DIFF
--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -82,6 +82,28 @@
                 <version>${camel-version}</version>
             </dependency>
 
+            <!-- Overrides vertx version from fabric8 kubernetes-httpclient-vertx -->
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-core</artifactId>
+                <version>${vertx-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-web-client</artifactId>
+                <version>${vertx-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-web-common</artifactId>
+                <version>${vertx-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-auth-common</artifactId>
+                <version>${vertx-version}</version>
+            </dependency>
+
             <!-- Insert third party overrides here -->
             <dependency>
                 <groupId>org.yaml</groupId>


### PR DESCRIPTION
Overrides vertx dependencies pulled by io.fabric8:kubernetes-httpclient-vertx (used by camel-kubernetes), which resolves to a different version than the rest of the vertx stack
```
camel-kubernetes/depTree.txt:   |  |  |  +- io.vertx:vertx-core:jar:4.5.24.redhat-00001:runtime
camel-kubernetes/depTree.txt:   |  |  |  \- io.vertx:vertx-web-client:jar:4.5.24.redhat-00001:runtime
camel-kubernetes/depTree.txt:   |  |  |     +- io.vertx:vertx-web-common:jar:4.5.24.redhat-00001:runtime
camel-kubernetes/depTree.txt:   |  |  |     \- io.vertx:vertx-auth-common:jar:4.5.24.redhat-00001:runtime
```