### PR TITLE
Override version of netty-codec-http3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
         <jobjc-version>3.0.0</jobjc-version>
         <kryo-version>2.24.0</kryo-version>
         <narayana-spring-boot.version>3.5.0.redhat-00056</narayana-spring-boot.version>
+        <netty-42-version>4.2.15.Final</netty-42-version>
         <openshift-maven-plugin-version>1.19.0.redhat-00014</openshift-maven-plugin-version>
         <org-json-json-version>20250517</org-json-json-version>
         <parsson-version>1.1.7</parsson-version>
@@ -240,6 +241,11 @@
         <groupId>org.json</groupId>
         <artifactId>json</artifactId>
         <version>${org-json-json-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http3</artifactId>
+        <version>${netty-42-version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -5103,7 +5103,7 @@
       <dependency>
         <groupId>org.apache.tomcat</groupId>
         <artifactId>tomcat-catalina</artifactId>
-        <version>10.1.54</version>
+        <version>10.1.55</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>

--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -309,6 +309,13 @@
                 <scope>import</scope>
             </dependency>
 
+            <!-- Not in netty-4.1 but being used -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http3</artifactId>
+                <version>${netty-42-version}</version>
+            </dependency>
+
             <!-- Override for reactor-netty-http -->
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>


### PR DESCRIPTION
netty-codec-http3 is a netty 4.2 only artifact - it is being pulled in through camel-azure* but we want to use the most recent 4.2 version of this.     Camel is aligned to netty 4.1.135.Final through the netty-bom, but as netty-codec-http3 is a 4.2 only artifact it does not appear in the 4.1.135.Final netty-bom and we need to specify it separately.

Add an override for netty-codec-http3 so the most recent version is pulled in the camel-azure* dependency trees.
