### PR TITLE
Align header constants with upstream CAMEL-23526 and CAMEL-23716

### DIFF
--- a/components-starter/camel-cxf-soap-starter/src/test/java/org/apache/camel/component/cxf/soap/springboot/greeterroute/CxfPayloadProviderRouterTest.java
+++ b/components-starter/camel-cxf-soap-starter/src/test/java/org/apache/camel/component/cxf/soap/springboot/greeterroute/CxfPayloadProviderRouterTest.java
@@ -24,6 +24,7 @@ import jakarta.xml.ws.Service;
 
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.cxf.common.DataFormat;
+import org.apache.camel.component.cxf.common.message.CxfConstants;
 import org.apache.camel.component.cxf.jaxws.CxfEndpoint;
 import org.apache.camel.component.cxf.spring.jaxws.CxfSpringEndpoint;
 import org.apache.camel.spring.boot.CamelAutoConfiguration;
@@ -173,8 +174,9 @@ public class CxfPayloadProviderRouterTest extends AbstractCXFGreeterRouterTest {
                 @Override
                 public void configure() {
                     from("cxf:bean:routerEndpoint")
-                            .setHeader("operationNamespace", constant("http://camel.apache.org/cxf/jaxws/dispatch"))
-                            .setHeader("operationName", constant("Invoke"))
+                            .setHeader(CxfConstants.OPERATION_NAMESPACE,
+                                    constant("http://camel.apache.org/cxf/jaxws/dispatch"))
+                            .setHeader(CxfConstants.OPERATION_NAME, constant("Invoke"))
                             .to("cxf:bean:serviceEndpoint");
                 }
             };

--- a/components-starter/camel-salesforce-starter/src/test/java/org/apache/camel/component/salesforce/springboot/RawPayloadTest.java
+++ b/components-starter/camel-salesforce-starter/src/test/java/org/apache/camel/component/salesforce/springboot/RawPayloadTest.java
@@ -167,8 +167,8 @@ public class RawPayloadTest extends AbstractSalesforceTestBase {
                 requestBody = "{ \"request\" : \"mock\" }";
             }
             headers = new HashMap<>();
-            headers.put("sObjectId", "mockId");
-            headers.put("sObjectIdValue", "mockIdValue");
+            headers.put(SalesforceEndpointConfig.SOBJECT_ID, "mockId");
+            headers.put(SalesforceEndpointConfig.SOBJECT_EXT_ID_VALUE, "mockIdValue");
             headers.put("id", "mockId");
             headers.put(SalesforceEndpointConfig.APEX_QUERY_PARAM_PREFIX + "id", "mockId");
 


### PR DESCRIPTION
## Summary

- Fix CxfPayloadProviderRouterTest: use `CxfConstants.OPERATION_NAME`/`OPERATION_NAMESPACE` instead of literal strings (CAMEL-23526)
- Fix RawPayloadTest: use `SalesforceEndpointConfig.SOBJECT_ID`/`SOBJECT_EXT_ID_VALUE` instead of literal strings (CAMEL-23716)

## Root Cause

Upstream Camel renamed header constants as part of the CAMEL-23577 initiative to align Exchange header names with the `Camel<Component>` naming convention. The plain Camel tests were updated in the same commits, but the camel-spring-boot test copies still used hardcoded literal strings (`"operationName"`, `"sObjectId"`, etc.) which are no longer recognized after the rename.

This caused 12 downstream test failures per platform (2 CXF + 10 Salesforce) on the productized tag `4.18.1.redhat-00026`.

## Upstream references

- CAMEL-23526: `operationName` → `CamelCxfOperationName` (commit `96f50120e62c`)
- CAMEL-23716: `sObjectId` → `CamelSalesforceSObjectId` (commit `35886b0af9d7`)

## Test plan

- [x] Verified locally: CxfPayloadProviderRouterTest 4/4 passed, RawPayloadTest 39/39 passed on branch HEAD
- [ ] Run downstream-tests Jenkins job with this fix

Fixes: CSB-9560, CSB-9824

🤖 Generated with [Claude Code](https://claude.com/claude-code)