### PR TITLE
Revert "Override version of netty-codec-http3"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,6 @@
         <jobjc-version>3.0.0</jobjc-version>
         <kryo-version>2.24.0</kryo-version>
         <narayana-spring-boot.version>3.5.0.redhat-00056</narayana-spring-boot.version>
-        <netty-42-version>4.2.15.Final</netty-42-version>
         <openshift-maven-plugin-version>1.19.0.redhat-00014</openshift-maven-plugin-version>
         <org-json-json-version>20250517</org-json-json-version>
         <parsson-version>1.1.7</parsson-version>
@@ -241,11 +240,6 @@
         <groupId>org.json</groupId>
         <artifactId>json</artifactId>
         <version>${org-json-json-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-codec-http3</artifactId>
-        <version>${netty-42-version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/tooling/camel-spring-boot-dependencies/pom.xml
+++ b/tooling/camel-spring-boot-dependencies/pom.xml
@@ -5103,7 +5103,7 @@
       <dependency>
         <groupId>org.apache.tomcat</groupId>
         <artifactId>tomcat-catalina</artifactId>
-        <version>10.1.55</version>
+        <version>10.1.54</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>

--- a/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
+++ b/tooling/redhat-camel-spring-boot-bom-generator/src/main/resources/pom.xml
@@ -316,13 +316,6 @@
                 <scope>import</scope>
             </dependency>
 
-            <!-- Not in netty-4.1 but being used -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-http3</artifactId>
-                <version>${netty-42-version}</version>
-            </dependency>
-
             <!-- Override for reactor-netty-http -->
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>


### PR DESCRIPTION
Reverts jboss-fuse/camel-spring-boot#683

https://redhat.atlassian.net/browse/CSB-9322 only affects etty-codec-http and netty-codec-http2

and this PR was causing https://redhat.atlassian.net/browse/CSB-9906